### PR TITLE
C++14 conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 14)
 
 project(Phoebe CXX)
 

--- a/src/algebra/Matrix.h
+++ b/src/algebra/Matrix.h
@@ -290,9 +290,15 @@ std::vector<std::tuple<long, long>> Matrix<T>::getAllLocalWavevectors(
     BaseBandStructure& bandStructure) {
   std::vector<std::tuple<long, long>> wavevectorPairs;
   for (long k = 0; k < numElements_; k++) {
-    auto [is1, is2] = local2Global(k);  // bloch indices
-    auto [ik1, ib1] = bandStructure.getIndex(is1);
-    auto [ik2, ib2] = bandStructure.getIndex(is2);
+    auto tup = local2Global(k);
+    auto is1 = std::get<0>(tup);
+    auto is2 = std::get<1>(tup);  // bloch indices
+    auto tup1 = bandStructure.getIndex(is1);
+    auto ik1 = std::get<0>(tup1);
+    auto ib1 = std::get<1>(tup1);
+    auto tup2 = bandStructure.getIndex(is2);
+    auto ik2 = std::get<0>(tup2);
+    auto ib2 = std::get<1>(tup2);
     // make a pair of these wavevectors
     auto t = std::make_tuple(ik1.get(), ik2.get());
     // add to list if unique

--- a/src/algebra/PMatrix.h
+++ b/src/algebra/PMatrix.h
@@ -418,9 +418,15 @@ std::vector<std::pair<int, int>> ParallelMatrix<T>::getAllLocalWavevectors(
 
   std::set<std::pair<int,int>> x;
   for (long k = 0; k < numLocalElements_; k++) {
-    auto [is1, is2] = local2Global(k);  // bloch indices
-    auto [ik1, ib1] = bandStructure.getIndex(is1);
-    auto [ik2, ib2] = bandStructure.getIndex(is2);
+    auto tup = local2Global(k);
+    auto is1 = std::get<0>(tup);
+    auto is2 = std::get<1>(tup);  // bloch indices
+    auto tup1 = bandStructure.getIndex(is1);
+    auto ik1 = std::get<0>(tup1);
+    auto ib1 = std::get<1>(tup1);
+    auto tup2 = bandStructure.getIndex(is2);
+    auto ik2 = std::get<0>(tup2);
+    auto ib2 = std::get<1>(tup2);
     std::pair<int,int> xx = std::make_pair(ik1.get(), ik2.get());
     x.insert(xx);
   }

--- a/src/apps/app.cpp
+++ b/src/apps/app.cpp
@@ -19,6 +19,11 @@
 
 // app factory
 std::unique_ptr<App> App::loadApp(const std::string &choice) {
+  const std::vector<std::string> choices = {
+      "phononTransport",      "phononDos",           "electronWannierDos",
+      "electronFourierDos",   "phononBands",         "electronWannierBands",
+      "electronFourierBands", "electronPolarization"};
+
   // check if the app choice is valid, otherwise we stop.
   if (std::find(choices.begin(), choices.end(), choice) == choices.end()) {
     Error e("The app name is not valid, didn't find an app to launch.");

--- a/src/apps/app.h
+++ b/src/apps/app.h
@@ -43,10 +43,6 @@ public:
   virtual void checkRequirements(Context &context);
 
 protected:
-  static const inline std::vector<std::string> choices{
-      "phononTransport",      "phononDos",           "electronWannierDos",
-      "electronFourierDos",   "phononBands",         "electronWannierBands",
-      "electronFourierBands", "electronPolarization"};
 
   void throwErrorIfUnset(const std::string &x, const std::string &name);
   void throwErrorIfUnset(const std::vector<std::string> &x,

--- a/src/apps/bands_app.cpp
+++ b/src/apps/bands_app.cpp
@@ -10,7 +10,9 @@ void PhononBandsApp::run(Context &context) {
     std::cout << "Starting phonon bands calculation" << std::endl;
 
     // Read the necessary input files
-    auto [crystal, phononH0] = QEParser::parsePhHarmonic(context);
+    auto tup = QEParser::parsePhHarmonic(context);
+ auto crystal = std::get<0>(tup);
+ auto phononH0 = std::get<1>(tup);
 
     // first we make compute the band structure on the fine grid
     PathPoints pathPoints(crystal, context.getPathExtrema(),
@@ -46,7 +48,9 @@ void ElectronWannierBandsApp::run(Context &context) {
     std::cout << "Starting electron (Wannier) bands calculation" << std::endl;
 
     // Read the necessary input files
-    auto [crystal, electronH0] = QEParser::parseElHarmonicWannier(context);
+    auto tup = QEParser::parseElHarmonicWannier(context);
+ auto crystal = std::get<0>(tup);
+ auto electronH0 = std::get<1>(tup);
 
     // first we make compute the band structure on the fine grid
     PathPoints pathPoints(crystal, context.getPathExtrema(),
@@ -81,7 +85,9 @@ void ElectronFourierBandsApp::run(Context &context) {
     std::cout << "Starting electron (Fourier) bands calculation" << std::endl;
 
     // Read the necessary input files
-    auto [crystal, electronH0] = QEParser::parseElHarmonicFourier(context);
+    auto tup = QEParser::parseElHarmonicFourier(context);
+ auto crystal = std::get<0>(tup);
+ auto electronH0 = std::get<1>(tup);
 
     // first we make compute the band structure on the fine grid
     PathPoints pathPoints(crystal, context.getPathExtrema(),

--- a/src/apps/dos_app.cpp
+++ b/src/apps/dos_app.cpp
@@ -8,7 +8,7 @@
 #include "electron_h0_fourier.h"
 #include "utilities.h"
 #include "qe_input_parser.h"
-#include "../mpi/mpiHelper.h" 
+#include "../mpi/mpiHelper.h"
 #include "full_points.h"
 
 // Compute the DOS with the tetrahedron method
@@ -17,7 +17,9 @@ void PhononDosApp::run(Context &context) {
         std::cout << "Starting phonon DoS calculation" << std::endl;
 
     // Read the necessary input files
-    auto [crystal, phononH0] = QEParser::parsePhHarmonic(context);
+    auto tup = QEParser::parsePhHarmonic(context);
+ auto crystal = std::get<0>(tup);
+ auto phononH0 = std::get<1>(tup);
 
     // first we make compute the band structure on the fine grid
     FullPoints fullPoints(crystal, context.getQMesh());
@@ -37,7 +39,7 @@ void PhononDosApp::run(Context &context) {
     // create instructions about how to divide up the work
     std::vector<int> divs;
     divs = mpi->divideWork(numEnergies);
-    // the amount of values this process has to take care of  
+    // the amount of values this process has to take care of
     int start = divs[0];
     int stop = divs[1];
     int workFraction = stop - start;
@@ -82,7 +84,9 @@ void ElectronWannierDosApp::run(Context &context) {
         std::cout << "Starting electronic DoS calculation" << std::endl;
 
     // Read the necessary input files
-    auto [crystal, h0] = QEParser::parseElHarmonicWannier(context);
+    auto tup = QEParser::parseElHarmonicWannier(context);
+ auto crystal = std::get<0>(tup);
+ auto h0 = std::get<1>(tup);
 
     // first we make compute the band structure on the fine grid
     FullPoints fullPoints(crystal, context.getKMesh());
@@ -102,7 +106,7 @@ void ElectronWannierDosApp::run(Context &context) {
     // create instructions about how to divide up the work
     std::vector<int> divs;
     divs = mpi->divideWork(numEnergies);
-    // the amount of values this process has to take care of  
+    // the amount of values this process has to take care of
     int start = divs[0];
     int stop = divs[1];
     int workFraction = stop - start;
@@ -150,7 +154,9 @@ void ElectronFourierDosApp::run(Context &context) {
         std::cout << "Starting electronic DoS calculation" << std::endl;
 
     // Read the necessary input files
-    auto [crystal, h0] = QEParser::parseElHarmonicFourier(context);
+    auto tup = QEParser::parseElHarmonicFourier(context);
+ auto crystal = std::get<0>(tup);
+ auto h0 = std::get<1>(tup);
 
     // first we make compute the band structure on the fine grid
     FullPoints fullPoints(crystal, context.getKMesh());
@@ -170,7 +176,7 @@ void ElectronFourierDosApp::run(Context &context) {
     // create instructions about how to divide up the work
     std::vector<int> divs;
     divs = mpi->divideWork(numEnergies);
-    // the amount of values this process has to take care of  
+    // the amount of values this process has to take care of
     int start = divs[0];
     int stop = divs[1];
     int workFraction = stop - start;

--- a/src/apps/phonon_transport_app.cpp
+++ b/src/apps/phonon_transport_app.cpp
@@ -23,7 +23,9 @@ void PhononTransportApp::run(Context &context) {
 
   // Read the necessary input files
 
-  auto [crystal, phononH0] = QEParser::parsePhHarmonic(context);
+  auto tup = QEParser::parsePhHarmonic(context);
+  auto crystal = std::get<0>(tup);
+  auto phononH0 = std::get<1>(tup);
 
   // first we make compute the band structure on the fine grid
 
@@ -41,8 +43,9 @@ void PhononTransportApp::run(Context &context) {
   if ( mpi->mpiHead()) {
     std::cout << "\n" << "Constructing the band structure" << std::endl;
   }
-  auto [bandStructure, statisticsSweep] =
-      ActiveBandStructure::builder(context, phononH0, fullPoints);
+  auto tup1 =      ActiveBandStructure::builder(context, phononH0, fullPoints);
+  auto bandStructure = std::get<0>(tup1);
+  auto statisticsSweep = std::get<1>(tup1);
   if ( mpi->mpiHead()) {
     std::cout << "Done!\n" << std::endl;
   }
@@ -273,7 +276,9 @@ void PhononTransportApp::run(Context &context) {
       std::cout << "Starting relaxons BTE solver" << std::endl;
     }
     scatteringMatrix.a2Omega();
-    auto [eigenvalues, eigenvectors] = scatteringMatrix.diagonalize();
+    auto tup = scatteringMatrix.diagonalize();
+    auto eigenvalues = std::get<0>(tup);
+    auto eigenvectors = std::get<1>(tup);
     // EV such that Omega = V D V^-1
     // eigenvectors(phonon index, eigenvalue index)
 
@@ -286,7 +291,10 @@ void PhononTransportApp::run(Context &context) {
                     crystal.getVolumeUnitCell(context.getDimensionality()) /
                     bandStructure.getNumPoints(true);
 
-      auto [imu, it, idim] = relaxonV.loc2Glob(iCalc);
+      auto tup1 = relaxonV.loc2Glob(iCalc);
+      auto imu = std::get<0>(tup1);
+      auto it = std::get<1>(tup1);
+      auto idim = std::get<2>(tup1);
       int idimIndex = idim.get();
       auto jCalc = boseEigenvector.glob2Loc(imu, it, DimIndex(0));
       for (long is = 0; is < bandStructure.getNumStates(); is++) {

--- a/src/apps/polarization_app.cpp
+++ b/src/apps/polarization_app.cpp
@@ -12,7 +12,9 @@ void ElectronPolarizationApp::run(Context &context) {
     std::cout << "Starting electron polarization calculation" << std::endl;
 
     // Read the necessary input files
-    auto [crystal, h0] = QEParser::parseElHarmonicWannier(context);
+    auto tup = QEParser::parseElHarmonicWannier(context);
+    auto crystal = std::get<0>(tup);
+    auto h0 = std::get<1>(tup);
 
     // first we make compute the band structure on the fine grid
     FullPoints points(crystal, context.getKMesh());
@@ -33,7 +35,7 @@ void ElectronPolarizationApp::run(Context &context) {
                 h0.getBerryConnection(point);
         for (long ib = 0; ib < h0.getNumBands(); ib++) {
             for (long i = 0; i < 3; i++) {
-                std::complex x = thisBerryConnection[i](ib, ib);
+                auto x = thisBerryConnection[i](ib, ib);
                 berryConnection(ik, ib, i) = x.real();
             }
         }

--- a/src/bands/bandstructure.cpp
+++ b/src/bands/bandstructure.cpp
@@ -265,12 +265,16 @@ long FullBandStructure::getNumStates() {
 }
 
 const double& FullBandStructure::getEnergy(const long &stateIndex) {
-    auto [ik,ib] = decompress2Indeces(stateIndex,getNumPoints(),numBands);
+  auto tup = decompress2Indeces(stateIndex,getNumPoints(),numBands);
+  auto ik = std::get<0>(tup);
+  auto ib = std::get<1>(tup);
     return energies(ib, ik);
 }
 
 Eigen::Vector3d FullBandStructure::getGroupVelocity(const long &stateIndex) {
-    auto [ik,ib] = decompress2Indeces(stateIndex,getNumPoints(),numBands);
+  auto tup = decompress2Indeces(stateIndex,getNumPoints(),numBands);
+  auto ik = std::get<0>(tup);
+  auto ib = std::get<1>(tup);
     Eigen::Vector3d vel;
     for (long i = 0; i < 3; i++) {
         long ind = compress3Indeces(ib, ib, i, numBands, numBands, 3);
@@ -280,12 +284,16 @@ Eigen::Vector3d FullBandStructure::getGroupVelocity(const long &stateIndex) {
 }
 
 Eigen::Vector3d FullBandStructure::getWavevector(const long &stateIndex) {
-    auto [ik,ib] = decompress2Indeces(stateIndex,getNumPoints(),numBands);
+  auto tup = decompress2Indeces(stateIndex,getNumPoints(),numBands);
+  auto ik = std::get<0>(tup);
+  auto ib = std::get<1>(tup);
     return points.getPoint(ik).getCoords(Points::cartesianCoords,true);
 }
 
 double FullBandStructure::getWeight(const long &stateIndex) {
-  auto [ik,ib] = getIndex(stateIndex);
+  auto tup = getIndex(stateIndex);
+  auto ik = std::get<0>(tup);
+  auto ib = std::get<1>(tup);
   return points.getWeight(ik.get());
 }
 

--- a/src/bands/window.cpp
+++ b/src/bands/window.cpp
@@ -54,11 +54,14 @@ std::tuple<std::vector<double>, std::vector<long>> Window::apply(
             dndeMax(ib) = particle.getDnde(energies(ib), temperatureMax,
                     chemicalPotentialMin);
         }
-        auto [filteredEnergies, bandExtrema] = internalPopWindow(energies,
-                dndtMin, dndtMax, dndeMin, dndeMax);
+        auto tup = internalPopWindow(energies,                dndtMin, dndtMax, dndeMin, dndeMax);
+        auto filteredEnergies = std::get<0>(tup);
+        auto bandExtrema = std::get<1>(tup);
         return {filteredEnergies, bandExtrema};
     } else if (method == energy) {
-        auto [filteredEnergies, bandExtrema] = internalEnWindow(energies);
+      auto tup = internalEnWindow(energies);
+      auto filteredEnergies = std::get<0>(tup);
+      auto bandExtrema = std::get<1>(tup);
         return {filteredEnergies, bandExtrema};
     } else { // no filter
         numBands = energies.size();

--- a/src/bte/basevector_bte.cpp
+++ b/src/bte/basevector_bte.cpp
@@ -88,7 +88,10 @@ BaseVectorBTE BaseVectorBTE::baseOperator(BaseVectorBTE &that,
 
   } else if (that.dimensionality == 1) {
     for (long iCalc = 0; iCalc < numCalcs; iCalc++) {
-      auto [imu, it, idim] = loc2Glob(iCalc);
+      auto tup = loc2Glob(iCalc);
+      auto imu = std::get<0>(tup);
+      auto it = std::get<1>(tup);
+      auto idim = std::get<2>(tup);
       auto i2 = that.glob2Loc(imu, it, DimIndex(0));
 
       if (operatorType == operatorSums) {
@@ -151,7 +154,9 @@ BaseVectorBTE BaseVectorBTE::operator*(ParallelMatrix<double> &matrix) {
   BaseVectorBTE newPopulation = *this;
   newPopulation.data.setZero();
   for (long iCalc = 0; iCalc < numCalcs; iCalc++) {
-    for (auto [i, j] : matrix.getAllLocalStates()) {
+    for (auto tup : matrix.getAllLocalStates()) {
+      auto i = std::get<0>(tup);
+      auto j = std::get<1>(tup);
       newPopulation.data(iCalc, i) = matrix(i, j) * data(iCalc, j);
     }
   }
@@ -206,7 +211,9 @@ long BaseVectorBTE::glob2Loc(const ChemPotIndex &imu, const TempIndex &it,
 
 std::tuple<ChemPotIndex, TempIndex, DimIndex> BaseVectorBTE::loc2Glob(
     const long &i) {
-  auto [imu, it, idim] =
-      decompress3Indeces(i, numChemPots, numTemps, dimensionality);
+  auto tup =      decompress3Indeces(i, numChemPots, numTemps, dimensionality);
+  auto imu = std::get<0>(tup);
+  auto it = std::get<1>(tup);
+  auto idim = std::get<2>(tup);
   return {ChemPotIndex(imu), TempIndex(it), DimIndex(idim)};
 }

--- a/src/bte/drift.cpp
+++ b/src/bte/drift.cpp
@@ -11,7 +11,10 @@ BulkTDrift::BulkTDrift(StatisticsSweep &statisticsSweep_,
         Eigen::Vector3d velocity = bandStructure.getGroupVelocity(is);
 
         for (long iCalc = 0; iCalc < numCalcs; iCalc++) {
-            auto [imu,it,idim] = loc2Glob(iCalc);
+            auto tup = loc2Glob(iCalc);
+ auto imu = std::get<0>(tup);
+ auto it = std::get<1>(tup);
+ auto idim = std::get<2>(tup);
             int idimIndex = idim.get();
             double vel = velocity(idimIndex);
             auto calcStat = statisticsSweep.getCalcStatistics(it, imu);
@@ -35,7 +38,10 @@ BulkEDrift::BulkEDrift(StatisticsSweep &statisticsSweep_,
         Eigen::Vector3d velocity = bandStructure.getGroupVelocity(is);
 
         for (long iCalc = 0; iCalc < numCalcs; iCalc++) {
-            auto [imu,it,idim] = loc2Glob(iCalc);
+            auto tup = loc2Glob(iCalc);
+ auto imu = std::get<0>(tup);
+ auto it = std::get<1>(tup);
+ auto idim = std::get<2>(tup);
             int idimIndex = idim.get();
             double vel = velocity(idimIndex);
             auto calcStat = statisticsSweep.getCalcStatistics(it, imu);
@@ -58,7 +64,10 @@ Vector0::Vector0(StatisticsSweep &statisticsSweep_,
     Particle particle = bandStructure.getParticle();
 
     for (long iCalc = 0; iCalc < numCalcs; iCalc++) {
-        auto [imu,it,idim] = loc2Glob(iCalc);
+        auto tup = loc2Glob(iCalc);
+ auto imu = std::get<0>(tup);
+ auto it = std::get<1>(tup);
+ auto idim = std::get<2>(tup);
         auto calcStat = statisticsSweep.getCalcStatistics(it, imu);
         double temp = calcStat.temperature;
         double chemPot = calcStat.chemicalPotential;

--- a/src/bte/helper_3rd_state.cpp
+++ b/src/bte/helper_3rd_state.cpp
@@ -18,7 +18,9 @@ Helper3rdState::Helper3rdState(BaseBandStructure &innerBandStructure_,
   // 2 - the mesh is gamma-centered
   // 3 - the mesh is complete (if q1 and q2 are only around 0, q3 might be
   //     at the border)
-  auto [mesh, offset] = outerBandStructure.getPoints().getMesh();
+  auto tup = outerBandStructure.getPoints().getMesh();
+ auto mesh = std::get<0>(tup);
+ auto offset = std::get<1>(tup);
   if ((&innerBandStructure == &outerBandStructure) && (offset.norm() == 0.) &&
       innerBandStructure.hasWindow() == 0) {
     storedAllQ3 = true;
@@ -34,7 +36,9 @@ Helper3rdState::Helper3rdState(BaseBandStructure &innerBandStructure_,
 
     // first, we build the full grid that the 3rd point would fall into
     auto innerPoints = innerBandStructure.getPoints();
-    auto [mesh, offset] = innerPoints.getMesh();
+    auto tup = innerPoints.getMesh();
+ auto mesh = std::get<0>(tup);
+ auto offset = std::get<1>(tup);
     fullPoints3 = std::make_unique<FullPoints>(
         innerBandStructure.getPoints().getCrystal(), mesh, offset);
 
@@ -233,8 +237,12 @@ void Helper3rdState::prepare(const std::vector<long> q1Indexes,
       Eigen::Vector3d q3Plus = q1 + q2;
       Eigen::Vector3d q3Mins = q1 - q2;
 
-      auto [energies3Plus, eigvecs3Plus] = h0->diagonalizeFromCoords(q3Plus);
-      auto [energies3Mins, eigvecs3Mins] = h0->diagonalizeFromCoords(q3Mins);
+      auto tup = h0->diagonalizeFromCoords(q3Plus);
+ auto energies3Plus = std::get<0>(tup);
+ auto eigvecs3Plus = std::get<1>(tup);
+      auto tup1 = h0->diagonalizeFromCoords(q3Mins);
+ auto energies3Mins = std::get<0>(tup1);
+ auto eigvecs3Mins = std::get<1>(tup1);
 
       int nb3Plus = energies3Plus.size();
       int nb3Mins = energies3Mins.size();

--- a/src/bte/ph_scattering.cpp
+++ b/src/bte/ph_scattering.cpp
@@ -167,7 +167,9 @@ void PhScatteringMatrix::builder(ParallelMatrix<double> &matrix,
   LoopPrint loopPrint("computing scattering matrix", "q-points",
                       qPairIterator.size());
 
-  for (auto[iq1Indexes, iq2] : qPairIterator) {
+  for (auto tup : qPairIterator) {
+    auto iq1Indexes = std::get<0>(tup);
+    auto iq2 = std::get<1>(tup);
 
     Point q2 = innerBandStructure.getPoint(iq2);
     State states2 = innerBandStructure.getState(q2);
@@ -190,22 +192,44 @@ void PhScatteringMatrix::builder(ParallelMatrix<double> &matrix,
       int nb1 = state1Energies.size();
       Eigen::MatrixXd v1s = states1.getGroupVelocities();
 
+      /*
       auto[q3PlusC, state3PlusEnergies, nb3Plus, eigvecs3Plus, v3ps,
       bose3PlusData] = pointHelper.get(q1, q2, Helper3rdState::casePlus);
       auto[q3MinsC, state3MinsEnergies, nb3Mins, eigvecs3Mins, v3ms,
       bose3MinsData] = pointHelper.get(q1, q2, Helper3rdState::caseMins);
+      */
+      auto tup1 = pointHelper.get(q1, q2, Helper3rdState::casePlus);
+      auto tup2 = pointHelper.get(q1, q2, Helper3rdState::caseMins);
+
+      auto q3PlusC = std::get<0>(tup1);
+      auto state3PlusEnergies = std::get<1>(tup1);
+      auto nb3Plus = std::get<2>(tup1);
+      auto eigvecs3Plus = std::get<3>(tup1);
+      auto v3ps = std::get<4>(tup1);
+      auto bose3PlusData = std::get<5>(tup1);
+
+      auto q3MinsC = std::get<0>(tup2);
+      auto state3MinsEnergies = std::get<1>(tup2);
+      auto nb3Mins = std::get<2>(tup2);
+      auto eigvecs3Mins = std::get<3>(tup2);
+      auto v3ms = std::get<4>(tup2);
+      auto bose3MinsData = std::get<5>(tup2);
 
       DetachedState states3Plus(q3PlusC, state3PlusEnergies, numAtoms, nb3Plus,
                                 eigvecs3Plus);
       DetachedState states3Mins(q3MinsC, state3MinsEnergies, numAtoms, nb3Mins,
                                 eigvecs3Mins);
 
-      auto[couplingPlus, couplingMins] = coupling3Ph->getCouplingSquared(
-          states1, states2, states3Plus, states3Mins);
+      auto tup = coupling3Ph->getCouplingSquared(          states1, states2, states3Plus, states3Mins);
+      auto couplingPlus = std::get<0>(tup);
+      auto couplingMins = std::get<1>(tup);
 
 #pragma omp parallel for
       for (long ibbb = 0; ibbb < nb1 * nb2 * nb3Plus; ibbb++) {
-        auto[ib1, ib2, ib3] = decompress3Indeces(ibbb, nb1, nb2, nb3Plus);
+        auto tup = decompress3Indeces(ibbb, nb1, nb2, nb3Plus);
+        auto ib1 = std::get<0>(tup);
+        auto ib2 = std::get<1>(tup);
+        auto ib3 = std::get<2>(tup);
 
         double en1 = state1Energies(ib1);
         double en2 = state2Energies(ib2);
@@ -287,7 +311,10 @@ void PhScatteringMatrix::builder(ParallelMatrix<double> &matrix,
 
 #pragma omp parallel for
       for (long ibbb = 0; ibbb < nb1 * nb2 * nb3Mins; ibbb++) {
-        auto[ib1, ib2, ib3] = decompress3Indeces(ibbb, nb1, nb2, nb3Mins);
+        auto tup = decompress3Indeces(ibbb, nb1, nb2, nb3Mins);
+ auto ib1 = std::get<0>(tup);
+ auto ib2 = std::get<1>(tup);
+ auto ib3 = std::get<2>(tup);
 
         double en1 = state1Energies(ib1);
         double en2 = state2Energies(ib2);
@@ -377,7 +404,9 @@ void PhScatteringMatrix::builder(ParallelMatrix<double> &matrix,
   // Isotope scattering
   if (doIsotopes) {
     // for (auto [iq1, iq2] : qPairIterator) {
-    for (auto[iq1Indexes, iq2] : qPairIterator) {
+    for (auto tup : qPairIterator) {
+      auto iq1Indexes = std::get<0>(tup);
+      auto iq2 = std::get<1>(tup);
 #pragma omp parallel for
       for (auto iq1 : iq1Indexes) {
         State states2 = innerBandStructure.getState(iq2);

--- a/src/bte/scattering.cpp
+++ b/src/bte/scattering.cpp
@@ -135,7 +135,10 @@ VectorBTE ScatteringMatrix::offDiagonalDot(VectorBTE &inPopulation) {
   VectorBTE outPopulation = dot(inPopulation);
   // outPopulation = outPopulation - internalDiagonal * inPopulation;
   for (long i = 0; i < outPopulation.numCalcs; i++) {
-    auto [imu, it, idim] = inPopulation.loc2Glob(i);
+    auto tup = inPopulation.loc2Glob(i);
+ auto imu = std::get<0>(tup);
+ auto it = std::get<1>(tup);
+ auto idim = std::get<2>(tup);
     auto j = internalDiagonal.glob2Loc(imu, it, DimIndex(0));
     for (long is = 0; is < numStates; is++) {
       outPopulation.data(i, is) -=
@@ -152,7 +155,9 @@ VectorBTE ScatteringMatrix::dot(VectorBTE &inPopulation) {
     outPopulation.data.setZero();
     // note: we are assuming that ScatteringMatrix has numCalcs = 1
     for (int idim = 0; idim < inPopulation.dimensionality; idim++) {
-      for (auto [i1, j1] : theMatrix.getAllLocalStates()) {
+      for (auto tup : theMatrix.getAllLocalStates()) {
+auto i1 = std::get<0>(tup);
+auto j1 = std::get<1>(tup);
         outPopulation.data(idim, i1) +=
             theMatrix(i1, j1) * inPopulation.data(idim, j1);
       }
@@ -188,7 +193,9 @@ void ScatteringMatrix::a2Omega() {
   double temp = calcStatistics.temperature;
   double chemPot = calcStatistics.chemicalPotential;
 
-  for (auto [ind1, ind2] : theMatrix.getAllLocalStates()) {
+  for (auto tup : theMatrix.getAllLocalStates()) {
+auto ind1 = std::get<0>(tup);
+auto ind2 = std::get<1>(tup);
     if (std::find(excludeIndeces.begin(), excludeIndeces.end(), ind1) !=
         excludeIndeces.end())
       continue;
@@ -233,7 +240,9 @@ void ScatteringMatrix::omega2A() {
   double temp = calcStatistics.temperature;
   double chemPot = calcStatistics.chemicalPotential;
 
-  for (auto [ind1, ind2] : theMatrix.getAllLocalStates()) {
+  for (auto tup : theMatrix.getAllLocalStates()) {
+auto ind1 = std::get<0>(tup);
+auto ind2 = std::get<1>(tup);
     if (std::find(excludeIndeces.begin(), excludeIndeces.end(), ind1) !=
         excludeIndeces.end())
       continue;
@@ -300,7 +309,9 @@ VectorBTE ScatteringMatrix::getSingleModeTimes() {
 std::tuple<VectorBTE, ParallelMatrix<double>> ScatteringMatrix::diagonalize() {
   //    std::vector<double> eigenvalues;
   //    ParallelMatrix<double> eigenvectors;
-  auto [eigenvalues, eigenvectors] = theMatrix.diagonalize();
+  auto tup = theMatrix.diagonalize();
+ auto eigenvalues = std::get<0>(tup);
+ auto eigenvectors = std::get<1>(tup);
 
   // place eigenvalues in an VectorBTE object
   VectorBTE eigvals(statisticsSweep, outerBandStructure, 1);
@@ -344,7 +355,9 @@ ScatteringMatrix::getIteratorWavevectorPairs(const int &switchCase) {
         theMatrix.getAllLocalWavevectors(outerBandStructure);
     // find set of q2
     std::set<long> q2Indexes;
-    for ( auto [iq1,iq2] : x ) {
+    for ( auto tup : x ) {
+auto iq1 = std::get<0>(tup);
+auto iq2 = std::get<1>(tup);
       q2Indexes.insert(iq2);
     }
 
@@ -354,7 +367,9 @@ ScatteringMatrix::getIteratorWavevectorPairs(const int &switchCase) {
       std::vector<long> q1Indexes;
 
       // note: I'm assuming that the pairs in x are unique
-      for ( auto [iq1,iq2_] : x ) {
+      for ( auto tup : x ) {
+auto iq1 = std::get<0>(tup);
+auto iq2_ = std::get<1>(tup);
         if ( iq2 == iq2_ ) {
           q1Indexes.push_back(iq1);
         }

--- a/src/bte/vector_bte.cpp
+++ b/src/bte/vector_bte.cpp
@@ -66,7 +66,10 @@ VectorBTE VectorBTE::baseOperator(VectorBTE &that, const int &operatorType) {
     } else if (that.dimensionality == 1) {
 
         for (long iCalc = 0; iCalc < numCalcs; iCalc++) {
-            auto [imu,it,idim] = loc2Glob(iCalc);
+          auto tup = loc2Glob(iCalc);
+          auto imu = std::get<0>(tup);
+          auto it = std::get<1>(tup);
+          auto idim = std::get<2>(tup);
             auto i2 = that.glob2Loc(imu, it, DimIndex(0));
 
             if (operatorType == operatorSums) {
@@ -129,7 +132,9 @@ VectorBTE VectorBTE::operator *(ParallelMatrix<double> &matrix) {
   }
   VectorBTE newPopulation(statisticsSweep, bandStructure, dimensionality);
   newPopulation.data.setZero();
-  for (auto [i, j] : matrix.getAllLocalStates()) {
+  for (auto tup : matrix.getAllLocalStates()) {
+    auto i = std::get<0>(tup);
+    auto j = std::get<1>(tup);
     for (long iCalc = 0; iCalc < numCalcs; iCalc++) {
       newPopulation.data(iCalc, j) += data(iCalc, i) * matrix(i, j); // -5e-12
     }
@@ -175,7 +180,10 @@ VectorBTE VectorBTE::reciprocal() {
 void VectorBTE::canonical2Population() {
     auto particle = bandStructure.getParticle();
     for (long iCalc = 0; iCalc < numCalcs; iCalc++) {
-        auto [imu, it, idim] = loc2Glob(iCalc);
+      auto tup = loc2Glob(iCalc);
+      auto imu = std::get<0>(tup);
+      auto it = std::get<1>(tup);
+      auto idim = std::get<2>(tup);
         auto calcStatistics = statisticsSweep.getCalcStatistics(it, imu);
         auto temp = calcStatistics.temperature;
         auto chemPot = calcStatistics.chemicalPotential;
@@ -190,7 +198,10 @@ void VectorBTE::canonical2Population() {
 void VectorBTE::population2Canonical() {
     auto particle = bandStructure.getParticle();
     for (long iCalc = 0; iCalc < numCalcs; iCalc++) {
-        auto [imu, it, idim] = loc2Glob(iCalc);
+      auto tup = loc2Glob(iCalc);
+      auto imu = std::get<0>(tup);
+      auto it = std::get<1>(tup);
+      auto idim = std::get<2>(tup);
         auto calcStatistics = statisticsSweep.getCalcStatistics(it, imu);
         auto temp = calcStatistics.temperature;
         auto chemPot = calcStatistics.chemicalPotential;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -404,7 +404,9 @@ void Context::setupFromInput(std::string fileName) {
 
       // line with pair (key,value)
     } else if (lineHasParameter(line)) {
-      auto [parameterName, val] = parseParameterNameValue(line);
+      auto tup = parseParameterNameValue(line);
+      auto parameterName = std::get<0>(tup);
+      auto val = std::get<1>(tup);
 
       if (parameterName == "phD2FileName") {
         phD2FileName = parseString(val);
@@ -580,11 +582,15 @@ void Context::setupFromInput(std::string fileName) {
 
     } else {  // it might be a block, or its content
 
-      auto [blockName, value] = parseBlockNameValue(lines, lineCounter);
+      auto tup = parseBlockNameValue(lines, lineCounter);
+      auto blockName = std::get<0>(tup);
+      auto value = std::get<1>(tup);
 
       if (blockName == "crystal") {
-        auto [inputAtomicPositions_, inputAtomicSpecies_, inputSpeciesNames_] =
-            parseCrystal(value);
+        auto tup1 =            parseCrystal(value);
+        auto inputAtomicPositions_ = std::get<0>(tup1);
+        auto inputAtomicSpecies_ = std::get<1>(tup1);
+        auto inputSpeciesNames_ = std::get<2>(tup1);
         inputAtomicPositions = inputAtomicPositions_;
         inputAtomicSpecies = inputAtomicSpecies_;
         inputSpeciesNames = inputSpeciesNames_;

--- a/src/delta_function.cpp
+++ b/src/delta_function.cpp
@@ -62,7 +62,9 @@ double GaussianDeltaFunction::getSmearing(const double &energy, const long &iq,
 
 AdaptiveGaussianDeltaFunction::AdaptiveGaussianDeltaFunction(
         BaseBandStructure &bandStructure) {
-    auto [mesh,offset] = bandStructure.getPoints().getMesh();
+    auto tup = bandStructure.getPoints().getMesh();
+ auto mesh = std::get<0>(tup);
+ auto offset = std::get<1>(tup);
     qTensor = bandStructure.getPoints().getCrystal().getReciprocalUnitCell();
     qTensor.row(0) /= mesh(0);
     qTensor.row(1) /= mesh(1);
@@ -108,7 +110,9 @@ TetrahedronDeltaFunction::TetrahedronDeltaFunction(
         fullBandStructure(fullBandStructure_) {
 
     auto fullPoints = fullBandStructure.getPoints();
-    auto [grid, offset] = fullPoints.getMesh();
+    auto tup = fullPoints.getMesh();
+ auto grid = std::get<0>(tup);
+ auto offset = std::get<1>(tup);
     if (offset.norm() > 0.) {
         Error e("We didnt' implement tetrahedra with offsets", 1);
     }

--- a/src/harmonic/electron_h0_fourier.cpp
+++ b/src/harmonic/electron_h0_fourier.cpp
@@ -84,7 +84,9 @@ long ElectronH0Fourier::getNumBands() { return numBands; }
 std::tuple<Eigen::VectorXd, Eigen::MatrixXcd> ElectronH0Fourier::diagonalize(
     Point &point) {
   Eigen::Vector3d coords = point.getCoords(Points::cartesianCoords);
-  auto [energies, eigvecs] = diagonalizeFromCoords(coords);
+  auto tup = diagonalizeFromCoords(coords);
+  auto energies = std::get<0>(tup);
+  auto eigvecs = std::get<1>(tup);
   return {energies, eigvecs};
 }
 
@@ -126,7 +128,9 @@ FullBandStructure ElectronH0Fourier::populate(Points &fullPoints,
 
   for (long ik = 0; ik < fullBandStructure.getNumPoints(); ik++) {
     Point point = fullBandStructure.getPoint(ik);
-    auto [ens, eigvecs] = diagonalize(point);
+    auto tup = diagonalize(point);
+    auto ens = std::get<0>(tup);
+    auto eigvecs = std::get<1>(tup);
     fullBandStructure.setEnergies(point, ens);
     if (withVelocities) {
       auto vels = diagonalizeVelocity(point);
@@ -165,7 +169,9 @@ Eigen::Vector3cd ElectronH0Fourier::getDerivativeStarFunction(
 void ElectronH0Fourier::setPositionVectors() {
   // load the info on the supercell that we will use for the interpolation
   Eigen::Matrix3d directUnitCell = crystal.getDirectUnitCell();
-  auto [grid, offset] = coarsePoints.getMesh();
+  auto tup = coarsePoints.getMesh();
+  auto grid = std::get<0>(tup);
+  auto offset = std::get<1>(tup);
 
   // the cutoff specifies the grid on which lattice vectors are searched.
   // Given a lattice vector in integer coordinates R = (n0,n1,n2) in

--- a/src/harmonic/electron_h0_wannier.cpp
+++ b/src/harmonic/electron_h0_wannier.cpp
@@ -83,7 +83,9 @@ std::tuple<Eigen::VectorXd, Eigen::MatrixXcd> ElectronH0Wannier::diagonalize(
         Point &point) {
     Eigen::Vector3d k = point.getCoords(Points::cartesianCoords);
 
-    auto [energies,eigenvectors] = diagonalizeFromCoords(k);
+    auto tup = diagonalizeFromCoords(k);
+    auto energies = std::get<0>(tup);
+    auto eigenvectors = std::get<1>(tup);
 
     // note: the eigenvector matrix is the unitary transformation matrix U
     // from the Bloch to the Wannier gauge.
@@ -136,7 +138,9 @@ Eigen::Tensor<std::complex<double>, 3> ElectronH0Wannier::diagonalizeVelocityFro
     }
 
     // get the eigenvectors and the energies of the q-point
-    auto [energies,eigenvectors] = diagonalizeFromCoords(coords);
+    auto tup = diagonalizeFromCoords(coords);
+    auto energies = std::get<0>(tup);
+    auto eigenvectors = std::get<1>(tup);
 
     // now we compute the velocity operator, diagonalizing the expectation
     // value of the derivative of the dynamical matrix.
@@ -149,8 +153,12 @@ Eigen::Tensor<std::complex<double>, 3> ElectronH0Wannier::diagonalizeVelocityFro
         qMins(i) -= delta;
 
         // diagonalize the dynamical matrix at q+ and q-
-        auto [enPlus,eigPlus] = diagonalizeFromCoords(qPlus);
-        auto [enMins,eigMins] = diagonalizeFromCoords(qMins);
+        auto tup = diagonalizeFromCoords(qPlus);
+        auto enPlus = std::get<0>(tup);
+        auto eigPlus = std::get<1>(tup);
+        auto tup1 = diagonalizeFromCoords(qMins);
+        auto enMins = std::get<0>(tup1);
+        auto eigMins = std::get<1>(tup1);
 
         // build diagonal matrices with frequencies
         Eigen::MatrixXd enPlusMat(numBands, numBands);
@@ -251,7 +259,9 @@ FullBandStructure ElectronH0Wannier::populate(Points &fullPoints,
 
     for (long ik = 0; ik < fullBandStructure.getNumPoints(); ik++) {
         Point point = fullBandStructure.getPoint(ik);
-        auto [ens, eigvecs] = diagonalize(point);
+        auto tup = diagonalize(point);
+        auto ens = std::get<0>(tup);
+        auto eigvecs = std::get<1>(tup);
         fullBandStructure.setEnergies(point, ens);
         if (withVelocities) {
             auto vels = diagonalizeVelocity(point);
@@ -269,7 +279,9 @@ std::vector<Eigen::MatrixXcd> ElectronH0Wannier::getBerryConnection(
     Eigen::Vector3d k = point.getCoords(Points::cartesianCoords);
 
     // first we diagonalize the hamiltonian
-    auto [ens, eigvecs] = diagonalize(point);
+    auto tup = diagonalize(point);
+    auto ens = std::get<0>(tup);
+    auto eigvecs = std::get<1>(tup);
 
     // note: the eigenvector matrix is the unitary transformation matrix U
     // from the Bloch to the Wannier gauge.

--- a/src/harmonic/phonon_h0.cpp
+++ b/src/harmonic/phonon_h0.cpp
@@ -128,7 +128,9 @@ std::tuple<Eigen::VectorXd, Eigen::MatrixXcd> PhononH0::diagonalize(
     Point &point) {
   Eigen::Vector3d q = point.getCoords(Points::cartesianCoords);
   bool withMassScaling = true;
-  auto [energies, eigenvectors] = diagonalizeFromCoords(q, withMassScaling);
+  auto tup = diagonalizeFromCoords(q, withMassScaling);
+  auto energies = std::get<0>(tup);
+  auto eigenvectors = std::get<1>(tup);
   return {energies, eigenvectors};
 }
 
@@ -187,7 +189,9 @@ std::tuple<Eigen::VectorXd, Eigen::MatrixXcd> PhononH0::diagonalizeFromCoords(
 
   // once everything is ready, here we scale by masses and diagonalize
 
-  auto [energies, eigenvectors] = dyndiag(dyn);
+  auto tup = dyndiag(dyn);
+  auto energies = std::get<0>(tup);
+  auto eigenvectors = std::get<1>(tup);
 
   if (withMassScaling) {
     // we normalize with the mass.
@@ -216,7 +220,9 @@ FullBandStructure PhononH0::populate(Points &points, bool &withVelocities,
   for (long ik = 0; ik < fullBandStructure.getNumPoints(); ik++) {
     Point point = fullBandStructure.getPoint(ik);
 
-    auto [ens, eigvecs] = diagonalize(point);
+    auto tup = diagonalize(point);
+    auto ens = std::get<0>(tup);
+    auto eigvecs = std::get<1>(tup);
     fullBandStructure.setEnergies(point, ens);
 
     if (withVelocities) {
@@ -819,7 +825,7 @@ void PhononH0::setAcousticSumRule(const std::string &sumRule) {
   }
 
   if (mpi->mpiHead()) {
-    std::cout << "Start imposing " << sumRule << " acoustic sum rule." 
+    std::cout << "Start imposing " << sumRule << " acoustic sum rule."
 	      << std::endl;
   }
 
@@ -1387,7 +1393,7 @@ void PhononH0::setAcousticSumRule(const std::string &sumRule) {
 
   }
   if (mpi->mpiHead()) {
-    std::cout << "Finished imposing " << sumRule << " acoustic sum rule." 
+    std::cout << "Finished imposing " << sumRule << " acoustic sum rule."
 	      << std::endl;
   }
 }
@@ -1428,8 +1434,9 @@ Eigen::Tensor<std::complex<double>, 3> PhononH0::diagonalizeVelocityFromCoords(
   bool withMassScaling = false;
 
   // get the eigenvectors and the energies of the q-point
-  auto [energies, eigenvectors] =
-      diagonalizeFromCoords(coords, withMassScaling);
+  auto tup =      diagonalizeFromCoords(coords, withMassScaling);
+  auto energies = std::get<0>(tup);
+  auto eigenvectors = std::get<1>(tup);
 
   // now we compute the velocity operator, diagonalizing the expectation
   // value of the derivative of the dynamical matrix.
@@ -1443,8 +1450,12 @@ Eigen::Tensor<std::complex<double>, 3> PhononH0::diagonalizeVelocityFromCoords(
     qMins(i) -= deltaQ;
 
     // diagonalize the dynamical matrix at q+ and q-
-    auto [enPlus, eigPlus] = diagonalizeFromCoords(qPlus, withMassScaling);
-    auto [enMins, eigMins] = diagonalizeFromCoords(qMins, withMassScaling);
+    auto tup = diagonalizeFromCoords(qPlus, withMassScaling);
+    auto enPlus = std::get<0>(tup);
+    auto eigPlus = std::get<1>(tup);
+    auto tup1 = diagonalizeFromCoords(qMins, withMassScaling);
+    auto enMins = std::get<0>(tup1);
+    auto eigMins = std::get<1>(tup1);
 
     // build diagonal matrices with frequencies
     Eigen::MatrixXd enPlusMat(numBands, numBands);

--- a/src/observable/observable.cpp
+++ b/src/observable/observable.cpp
@@ -44,7 +44,9 @@ long Observable::glob2Loc(const ChemPotIndex &imu, const TempIndex &it) {
 }
 
 std::tuple<ChemPotIndex, TempIndex> Observable::loc2Glob(const long &i) {
-    auto [imu, it] = decompress2Indeces(i, numChemPots, numTemps);
+    auto tup = decompress2Indeces(i, numChemPots, numTemps);
+ auto imu = std::get<0>(tup);
+ auto it = std::get<1>(tup);
     return {ChemPotIndex(imu), TempIndex(it)};
 }
 

--- a/src/observable/onsager.cpp
+++ b/src/observable/onsager.cpp
@@ -87,7 +87,9 @@ void OnsagerCoefficients::calcFromPopulation(VectorBTE &nE, VectorBTE &nT) {
 
       int numChemPots = statisticsSweep.getNumChemicalPotentials();
       int numTemps = statisticsSweep.getNumTemperatures();
-      auto [imu, it] = decompress2Indeces(iCalc, numChemPots, numTemps);
+      auto tup = decompress2Indeces(iCalc, numChemPots, numTemps);
+      auto imu = std::get<0>(tup);
+      auto it = std::get<1>(tup);
 
       double chemicalPotential =
           statisticsSweep.getCalcStatistics(iCalc).chemicalPotential;

--- a/src/observable/phonon_thermal_cond.cpp
+++ b/src/observable/phonon_thermal_cond.cpp
@@ -74,7 +74,9 @@ void PhononThermalConductivity::calcFromPopulation(VectorBTE &n) {
         continue;
 
       for (long iCalc = 0; iCalc < numCalcs; iCalc++) {
-        auto [imu, it] = loc2Glob(iCalc);
+        auto tup = loc2Glob(iCalc);
+ auto imu = std::get<0>(tup);
+ auto it = std::get<1>(tup);
         for (long i = 0; i < dimensionality; i++) {
           long icPop = n.glob2Loc(imu, it, DimIndex(i));
           for (long j = 0; j < dimensionality; j++) {
@@ -119,7 +121,9 @@ void PhononThermalConductivity::calcVariational(VectorBTE &af, VectorBTE &f,
     #pragma omp for nowait
     for ( long is : bandStructure.parallelStateIterator() ) {
       for (long iCalc = 0; iCalc < numCalcs; iCalc++) {
-        auto [imu, it] = loc2Glob(iCalc);
+        auto tup = loc2Glob(iCalc);
+ auto imu = std::get<0>(tup);
+ auto it = std::get<1>(tup);
         for (long i = 0; i < dimensionality; i++) {
           long icPop1 = f.glob2Loc(imu, it, DimIndex(i));
           for (long j = 0; j < dimensionality; j++) {
@@ -162,7 +166,9 @@ void PhononThermalConductivity::calcFromRelaxons(SpecificHeat &specificHeat,
     #pragma omp for nowait
     for (long is = firstState; is < relaxationTimes.numStates; is++) {
       for (long iCalc = 0; iCalc < numCalcs; iCalc++) {
-        auto [imu, it] = loc2Glob(iCalc);
+        auto tup = loc2Glob(iCalc);
+ auto imu = std::get<0>(tup);
+ auto it = std::get<1>(tup);
         double c = specificHeat.get(imu, it);
 
         if (relaxationTimes.data(iCalc, is) <= 0.) continue;

--- a/src/observable/phonon_viscosity.cpp
+++ b/src/observable/phonon_viscosity.cpp
@@ -179,7 +179,9 @@ void PhononViscosity::calcFromRelaxons(Vector0 &vector0, VectorBTE &relTimes,
             // auto x2 = x.transpose() * eigenvectors;
 
             std::vector<double> x2(numStates,0.);
-            for ( auto [is1,is2] : eigenvectors.getAllLocalStates() ) {
+            for ( auto tup : eigenvectors.getAllLocalStates() ) {
+auto is1 = std::get<0>(tup);
+auto is2 = std::get<1>(tup);
                 x2[is2] += x(is1) * eigenvectors(is1,is2);
             }
             mpi->allReduceSum(&x2);

--- a/src/parser/qe_input_parser.cpp
+++ b/src/parser/qe_input_parser.cpp
@@ -765,7 +765,9 @@ QEParser::parseElHarmonicFourier(Context &context) {
     Error e("spin is not yet supported");
   }
 
-  auto [mesh, offset] = Points::findMesh(irredPoints);
+  auto tup = Points::findMesh(irredPoints);
+ auto mesh = std::get<0>(tup);
+ auto offset = std::get<1>(tup);
   FullPoints coarsePoints(crystal, mesh, offset);
 
   bool withVelocities = false;

--- a/src/points/points.cpp
+++ b/src/points/points.cpp
@@ -5,6 +5,9 @@
 #include "eigen.h"
 #include "utilities.h" // for mod()
 
+const int Points::crystalCoords = 0;
+const int Points::cartesianCoords = 1;
+
 // default constructors
 
 Points::Points(Crystal &crystal_, const Eigen::Vector3i &mesh_,

--- a/src/points/points.h
+++ b/src/points/points.h
@@ -178,8 +178,8 @@ public:
 
     // note: constexpr tells the compiler that the class member is
     // available at compilation time
-    static constexpr const int crystalCoords = 0;
-    static constexpr const int cartesianCoords = 1;
+    static const int crystalCoords;
+    static const int cartesianCoords;
 
     // given a wavevector of the reducible list in crystal coordinates,
     // finds the integer index ikIrr of the irreducible point in the irreducible

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -84,7 +84,9 @@ void DetachedState::getEigenvectors(
   long numAtoms = numBands1 / 3;
   eigs = Eigen::Tensor<std::complex<double>, 3>(3, numAtoms, numBands2);
   for (long i = 0; i < numBands1; i++) {
-    auto [iat, ic] = decompress2Indeces(i, numAtoms, 3);
+    auto tup = decompress2Indeces(i, numAtoms, 3);
+    auto iat = std::get<0>(tup);
+    auto ic = std::get<1>(tup);
     for (long j = 0; j < numBands2; j++) {
       eigs(ic, iat, j) = eigenvectors(i, j);
     }

--- a/test/band_structure_test.cpp
+++ b/test/band_structure_test.cpp
@@ -15,7 +15,9 @@ TEST(FullBandStructureTest, BandStructureStorage) {
   context.setPhD2FileName("../test/interaction3ph/QEspresso.fc");
 
   QEParser qeParser;
-  auto [crystal, phononH0] = qeParser.parsePhHarmonic(context);
+  auto tup = qeParser.parsePhHarmonic(context);
+ auto crystal = std::get<0>(tup);
+ auto phononH0 = std::get<1>(tup);
 
   // Number of atoms
   long numAtoms = crystal.getNumAtoms();
@@ -35,7 +37,9 @@ TEST(FullBandStructureTest, BandStructureStorage) {
 
   long ik = 7;
   Point point = bandStructure.getPoint(ik);
-  auto [ensT, eigvecsT] = phononH0.diagonalize(point);
+  auto tup1 = phononH0.diagonalize(point);
+ auto ensT = std::get<0>(tup1);
+ auto eigvecsT = std::get<1>(tup1);
   auto velsT = phononH0.diagonalizeVelocity(point);
 
   auto s = bandStructure.getState(ik);
@@ -60,7 +64,9 @@ TEST(FullBandStructureTest, BandStructureStorage) {
 
   std::complex<double> c2 = complexZero;
   for ( long i = 0; i<numBands; i++ ) {
-  	auto [iat,ic] = decompress2Indeces(i,numAtoms,3);
+  	auto tup = decompress2Indeces(i,numAtoms,3);
+ auto iat = std::get<0>(tup);
+ auto ic = std::get<1>(tup);
   	for ( long j = 0; j<numBands; j++ ) {
         c2 += pow(eigvecsT(i,j) - eigvecs(ic, iat, j), 2);
     }
@@ -70,7 +76,9 @@ TEST(FullBandStructureTest, BandStructureStorage) {
   // now we check that we get the same eigenvectors in the two different
   // shapes
   auto k = point.getCoords(Points::cartesianCoords);
-  auto [ensC, eigvecsC] = phononH0.diagonalizeFromCoords(k);
+  auto tup2 = phononH0.diagonalizeFromCoords(k);
+ auto ensC = std::get<0>(tup2);
+ auto eigvecsC = std::get<1>(tup2);
   x1 = (ens - ensC).norm();
   ASSERT_EQ(x1, 0.);
 

--- a/test/interaction3ph/interaction3phTest.cpp
+++ b/test/interaction3ph/interaction3phTest.cpp
@@ -29,7 +29,9 @@ TEST (Interaction3Ph, Coupling3Ph000) {
 	context.setSumRuleD2("simple");
 
 	QEParser qeParser;
-	auto [crystal,phononH0] = qeParser.parsePhHarmonic(context);
+	auto tup = qeParser.parsePhHarmonic(context);
+ auto crystal = std::get<0>(tup);
+ auto phononH0 = std::get<1>(tup);
 
 	IFC3Parser ifc3Parser;
 	auto coupling3Ph = ifc3Parser.parseFromShengBTE(context, crystal);
@@ -50,16 +52,23 @@ TEST (Interaction3Ph, Coupling3Ph000) {
 	q2.setZero();
 	q3.setZero();
 
-	auto [energies1,ev1] = phononH0.diagonalizeFromCoords(q1);
-	auto [energies2,ev2] = phononH0.diagonalizeFromCoords(q2);
-	auto [energies3,ev3] = phononH0.diagonalizeFromCoords(q3);
+	auto tup1 = phononH0.diagonalizeFromCoords(q1);
+ auto energies1 = std::get<0>(tup1);
+ auto ev1 = std::get<1>(tup1);
+	auto tup2 = phononH0.diagonalizeFromCoords(q2);
+ auto energies2 = std::get<0>(tup2);
+ auto ev2 = std::get<1>(tup2);
+	auto tup3 = phononH0.diagonalizeFromCoords(q3);
+ auto energies3 = std::get<0>(tup3);
+ auto ev3 = std::get<1>(tup3);
 
 	DetachedState s1(q1, energies, numBands, numBands, ev1, nullptr);
 	DetachedState s2(q2, energies, numBands, numBands, ev2, nullptr);
 	DetachedState s3(q3, energies, numBands, numBands, ev3, nullptr);
 
-	auto [couplingPlus,couplingMins] = coupling3Ph.getCouplingSquared(
-														s1, s2, s3, s3);
+	auto tup8 = coupling3Ph.getCouplingSquared(														s1, s2, s3, s3);
+ auto couplingPlus = std::get<0>(tup8);
+ auto couplingMins = std::get<1>(tup8);
 
 	// we load reference data
 
@@ -124,7 +133,9 @@ TEST (Interaction3Ph, Coupling3Ph210) {
 	context.setSumRuleD2("simple");
 
 	QEParser qeParser;
-	auto [crystal,phononH0] = qeParser.parsePhHarmonic(context);
+	auto tup = qeParser.parsePhHarmonic(context);
+ auto crystal = std::get<0>(tup);
+ auto phononH0 = std::get<1>(tup);
 
 	IFC3Parser ifc3Parser;
 	auto coupling3Ph = ifc3Parser.parseFromShengBTE(context, crystal);
@@ -147,9 +158,15 @@ TEST (Interaction3Ph, Coupling3Ph210) {
 	auto p1 = points.getPoint(iq1);
 	auto p2 = points.getPoint(iq2);
 	auto p3 = points.getPoint(iq3);
-	auto [energies1,evm1] = phononH0.diagonalize(p1);
-	auto [energies2,evm2] = phononH0.diagonalize(p2);
-	auto [energies3,evm3] = phononH0.diagonalize(p3);
+	auto tup1 = phononH0.diagonalize(p1);
+ auto energies1 = std::get<0>(tup1);
+ auto evm1 = std::get<1>(tup1);
+	auto tup2 = phononH0.diagonalize(p2);
+ auto energies2 = std::get<0>(tup2);
+ auto evm2 = std::get<1>(tup2);
+	auto tup3 = phononH0.diagonalize(p3);
+ auto energies3 = std::get<0>(tup3);
+ auto evm3 = std::get<1>(tup3);
 	auto q1 = p1.getCoords(Points::cartesianCoords);
 	auto q2 = p2.getCoords(Points::cartesianCoords);
 	auto q3 = p3.getCoords(Points::cartesianCoords);
@@ -163,8 +180,9 @@ TEST (Interaction3Ph, Coupling3Ph210) {
 	DetachedState s2(q2, energies, numBands, numBands, evm2, nullptr);
 	DetachedState s3(q3, energies, numBands, numBands, evm3, nullptr);
 
-	auto [couplingPlus,couplingMins] = coupling3Ph.getCouplingSquared(
-														s1, s2, s3, s3);
+	auto tup7 = coupling3Ph.getCouplingSquared(														s1, s2, s3, s3);
+ auto couplingPlus = std::get<0>(tup7);
+ auto couplingMins = std::get<1>(tup7);
 	// we load reference data
 
 	Eigen::Tensor<double,3> referenceCoupling(numBands,numBands,numBands);
@@ -232,8 +250,9 @@ TEST (Interaction3Ph, Coupling3Ph210) {
 	ASSERT_EQ((p3PlusTest.getCoords(Points::cartesianCoords)-p3Plus.getCoords(Points::cartesianCoords)).norm(), 0.);
 	ASSERT_EQ((p3MinsTest.getCoords(Points::cartesianCoords)-p3Mins.getCoords(Points::cartesianCoords)).norm(), 0.);
 
-	auto [couplingPlus2,couplingMins2] = coupling3Ph.getCouplingSquared(
-			states1, states2, states3Plus, states3Mins);
+	auto tup6 = coupling3Ph.getCouplingSquared(			states1, states2, states3Plus, states3Mins);
+ auto couplingPlus2 = std::get<0>(tup6);
+ auto couplingMins2 = std::get<1>(tup6);
 
 	auto en1 = states1.getEnergies();
 	auto en2 = states2.getEnergies();

--- a/test/interactionIsotopeTest.cpp
+++ b/test/interactionIsotopeTest.cpp
@@ -16,7 +16,9 @@ TEST (InteractionIsotope,Wphisoiq4) {
 	context.setPhD2FileName("../test/interaction3ph/QEspresso.fc");
 	context.setSumRuleD2("simple");
 	QEParser qeParser;
-	auto [crystal,phononH0] = qeParser.parsePhHarmonic(context);
+	auto tup = qeParser.parsePhHarmonic(context);
+ auto crystal = std::get<0>(tup);
+ auto phononH0 = std::get<1>(tup);
 
 	//Total number of wave vectors
 	int nq = 8*8*8;
@@ -57,7 +59,9 @@ TEST (InteractionIsotope,Wphisoiq4) {
 	//Eigenvector and angular frequencies at iq
 	int iq = 4; // = (0.5, 0, 0) in crystal coordinates
 	auto q1 = points.getPoint(iq);
-	auto [ens1,ev1] = phononH0.diagonalize(q1);
+	auto tup1 = phononH0.diagonalize(q1);
+ auto ens1 = std::get<0>(tup1);
+ auto ev1 = std::get<1>(tup1);
 
 	Eigen::Tensor<std::complex<double>,3> evt1(3,numAtoms,numBands);
 	Eigen::Tensor<std::complex<double>,3> evt2(3,numAtoms,numBands);
@@ -65,12 +69,16 @@ TEST (InteractionIsotope,Wphisoiq4) {
 	for ( int iq2 = 0; iq2 < nq; iq2++ ) { //integrate over
 		auto q2 = points.getPoint(iq2);
 		//Eigenvector and angular frequencies at jq
-		auto [ens2,ev2] = phononH0.diagonalize(q2);
+		auto tup = phononH0.diagonalize(q2);
+ auto ens2 = std::get<0>(tup);
+ auto ev2 = std::get<1>(tup);
 		//auto vsjq = phononH0.diagonalizeVelocity(jp);
 
 		for ( int i=0; i<numBands; i++ ) {
 			for ( int j=0; j<numBands; j++ ) {
-				auto [iat,idim] = decompress2Indeces(i,numAtoms,3);
+				auto tup = decompress2Indeces(i,numAtoms,3);
+ auto iat = std::get<0>(tup);
+ auto idim = std::get<1>(tup);
 				evt1(idim,iat,j) = ev1(i,j);
 				evt2(idim,iat,j) = ev2(i,j);
 			}

--- a/test/pointsTest.cpp
+++ b/test/pointsTest.cpp
@@ -25,7 +25,9 @@ TEST (PointsTest, PointsHandling) {
 	mesh << 4,4,4;
 	FullPoints points(crystal, mesh);
 
-	auto [mesh_,offset_] = points.getMesh();
+	auto tup = points.getMesh();
+ auto mesh_ = std::get<0>(tup);
+ auto offset_ = std::get<1>(tup);
 
 	EXPECT_EQ ((mesh-mesh_).norm(),0.);
 

--- a/test/velocityTest.cpp
+++ b/test/velocityTest.cpp
@@ -9,7 +9,9 @@ TEST (PhononH0, Velocity) {
 	context.setSumRuleD2("simple");
 
 	QEParser qeParser;
-	auto [crystal,phononH0] = qeParser.parsePhHarmonic(context);
+  auto tup = qeParser.parsePhHarmonic(context);
+  auto crystal = std::get<0>(tup);
+  auto phononH0 = std::get<1>(tup);
 
 	// now, let's create a fine mesh
 
@@ -20,7 +22,9 @@ TEST (PhononH0, Velocity) {
 	// pick a point close to gamma and get energies/velocities
 	long ik = 1;
 	auto p = points.getPoint(ik);
-	auto [omega,z] = phononH0.diagonalize(p);
+  auto tup1 = phononH0.diagonalize(p);
+  auto omega = std::get<0>(tup1);
+  auto z = std::get<1>(tup1);
 	auto v = phononH0.diagonalizeVelocity(p);
 
 	// take out the group velocity


### PR DESCRIPTION
I did all conversions as requested by compiler warnings when changing the C++ standard, with minimal changes (no clang-format).

Mostly tuple unpacking, except
- Change `constexpr static int` to `static int`, move definition to cpp file (although I think this is what `enum`s are for).
- Move `vector` of app choice strings from being an inline class member to a const local variable in the loadApp method.
- Change a `std::complex` without a template argument to `auto`.

For some reason, I can now successfully compile with both Intel and Clang compilers on my laptop (although the ExternalProject libraries are still built with GCC, ref. #7 comment 2).