### PR TITLE
Bugfix for activeBandStructure via BuildAsPostprocessing when points are filtered

### DIFF
--- a/src/bands/active_bandstructure.cpp
+++ b/src/bands/active_bandstructure.cpp
@@ -528,7 +528,6 @@ void ActiveBandStructure::buildOnTheFly(Window &window, Points &points,
   numStates = numEnStates;
 
   // initialize the raw data buffers of the activeBandStructure
-
   ActivePoints activePoints_(points, filter);
   activePoints = activePoints_;
   // construct the mapping from combined indices to Bloch indices
@@ -663,7 +662,7 @@ StatisticsSweep ActiveBandStructure::buildAsPostprocessing(
   // fullBandstructure, we would need to replace parallelIter with:
   //     parallelIter = mpi->divideWorkIter(points.getNumPoints());
   // All else will function once the swap is made. 
-  
+ 
   // Loop over the wavevectors belonging to each process 
   std::vector<long> parallelIter = fullBandStructure.getWavevectorIndices(); 
 
@@ -774,24 +773,27 @@ StatisticsSweep ActiveBandStructure::buildAsPostprocessing(
   // To accomodate the case where FullBS is distributed, 
   // we save the energies related to myFilteredPoints/Bands 
   // and then allReduce or allGather those instead
-
   for (unsigned long i=0; i<myFilteredPoints.size(); i++) {
 
-    long ik = myFilteredPoints[i];
-    auto ikIndex = WavevectorIndex(ik);
+    // index corresponding to index of wavevector in fullPoints
+    auto ikIndex = WavevectorIndex(myFilteredPoints[i]);
 
-    // use displacement array to get global idx of this point
-    // within the list of activePoints
-    int ikg = i + displacements[mpi->getRank()];
-    Point point = activePoints.getPoint(ikg);
+    // index corresponding to wavevector in activePoints 
+    // as well as any array of length numActivePoints, 
+    // like numBands, filteredBands
+    // ika = ikActive
+    int ika = i + displacements[mpi->getRank()];
+    auto ikaIndex = WavevectorIndex(ika);
+    Point point = activePoints.getPoint(ika);
 
+    // local ik, which corresponds to filteredPoints on this processs
     Eigen::VectorXd theseEnergies = fullBandStructure.getEnergies(ikIndex);
     Eigen::MatrixXcd theseEigenvectors = fullBandStructure.getEigenvectors(ikIndex);
 
     // copy energies into internal storage
-    Eigen::VectorXd eigEns(numBands(i));
+    Eigen::VectorXd eigEns(numBands(ika));
     long ibAct = 0;
-    for (long ibFull = filteredBands(ikg, 0); ibFull <= filteredBands(ikg, 1); ibFull++) {
+    for (long ibFull = filteredBands(ika, 0); ibFull <= filteredBands(ika, 1); ibFull++) {
       eigEns(ibAct) = theseEnergies(ibFull);
       ibAct++;
     }
@@ -802,9 +804,9 @@ StatisticsSweep ActiveBandStructure::buildAsPostprocessing(
       // we are reducing the basis size!
       // the first index has the size of the Hamiltonian
       // the second index has the size of the filtered bands
-      Eigen::MatrixXcd theseEigvecs(numFullBands, numBands(i));
+      Eigen::MatrixXcd theseEigvecs(numFullBands, numBands(ika));
       long ibAct = 0;
-      for (long ibFull = filteredBands(ikg, 0); ibFull <= filteredBands(ikg, 1); ibFull++) {
+      for (long ibFull = filteredBands(ika, 0); ibFull <= filteredBands(ika, 1); ibFull++) {
         theseEigvecs.col(ibAct) = theseEigenvectors.col(ibFull);
         ibAct++;
       }
@@ -814,7 +816,7 @@ StatisticsSweep ActiveBandStructure::buildAsPostprocessing(
   // reduce over internal data buffers
   mpi->allReduceSum(&energies);
   if (withEigenvectors) mpi->allReduceSum(&eigenvectors);
-  
+
   // compute velocities, store, reduce
   if (withVelocities) {
 
@@ -822,20 +824,23 @@ StatisticsSweep ActiveBandStructure::buildAsPostprocessing(
     #pragma omp parallel for
     for (unsigned long i=0; i<myFilteredPoints.size(); i++) {
 
-      // use the displacement array to find the global kidx
-      int ikg = i + displacements[mpi->getRank()];
-      Point point = activePoints.getPoint(ikg);
+      // index corresponding to wavevector in activePoints 
+      // as well as any array of length numActivePoints, 
+      // like numBands, filteredBands
+      // ika = ikActive
+      int ika = i + displacements[mpi->getRank()];
+      Point point = activePoints.getPoint(ika);
 
       // thisVelocity is a tensor of dimensions (ib, ib, 3)
       auto thisVelocity = h0.diagonalizeVelocity(point);
 
       // now we filter it
-      Eigen::Tensor<std::complex<double>, 3> thisVels(numBands(ikg),
-                                                      numBands(ikg), 3);
+      Eigen::Tensor<std::complex<double>, 3> thisVels(numBands(ika),
+                                                      numBands(ika), 3);
       long ib1New = 0;
-      for (long ib1Old = filteredBands(ikg, 0); ib1Old < filteredBands(ikg, 1) + 1; ib1Old++) {
+      for (long ib1Old = filteredBands(ika, 0); ib1Old < filteredBands(ika, 1) + 1; ib1Old++) {
         long ib2New = 0;
-        for (long ib2Old = filteredBands(ikg, 0); ib2Old < filteredBands(ikg, 1) + 1; ib2Old++) {
+        for (long ib2Old = filteredBands(ika, 0); ib2Old < filteredBands(ika, 1) + 1; ib2Old++) {
           for (long ic = 0; ic < 3; ic++) {
             thisVels(ib1New, ib2New, ic) = thisVelocity(ib1Old, ib2Old, ic);
           }

--- a/src/bands/active_bandstructure.cpp
+++ b/src/bands/active_bandstructure.cpp
@@ -783,7 +783,6 @@ StatisticsSweep ActiveBandStructure::buildAsPostprocessing(
     // like numBands, filteredBands
     // ika = ikActive
     int ika = i + displacements[mpi->getRank()];
-    auto ikaIndex = WavevectorIndex(ika);
     Point point = activePoints.getPoint(ika);
 
     // local ik, which corresponds to filteredPoints on this processs

--- a/test/PMatrix.cpp
+++ b/test/PMatrix.cpp
@@ -42,4 +42,11 @@ TEST (PMatrixTest, diagonalize) {
   }
   mpi->allReduceSum(&sumEigVecs); 
   EXPECT_EQ(sumEigVecs, 2*(1./sqrt(2)));
+
+  // check that the original matrix is still intact
+  if(pmat.indecesAreLocal(0,0)) { EXPECT_EQ(pmat(0,0), 0.0); }
+  if(pmat.indecesAreLocal(1,0)) { EXPECT_EQ(pmat(1,0), 1.0); }
+  if(pmat.indecesAreLocal(0,1)) { EXPECT_EQ(pmat(0,1), 1.0); }
+  if(pmat.indecesAreLocal(1,1)) { EXPECT_EQ(pmat(1,1), 0.0); }
+
 }

--- a/test/PMatrix.cpp
+++ b/test/PMatrix.cpp
@@ -1,0 +1,45 @@
+#include "gtest/gtest.h"
+#include "PMatrix.h" 
+#include <cmath>
+
+TEST (PMatrixTest, diagonalize) { 
+   
+  int numRows = 2; 
+  int numCols = 2; 
+
+  // we do not specify numBlocksRows/Cols, 
+  // as this matrix will have to be distributed using 
+  // a square process grid. Not specifying them 
+  // activates the default use case for a square process grid
+  ParallelMatrix<double> pmat = ParallelMatrix<double>(numRows,numCols); 
+
+  // construct a pauli matrix in a very brute force way
+  // let's first do sigma_x
+  if(pmat.indecesAreLocal(0,1)) pmat(0,1) = 1.0;
+  if(pmat.indecesAreLocal(1,0)) pmat(1,0) = 1.0;
+
+  auto tup = pmat.diagonalize(); 
+  auto eigenvalues = std::get<0>(tup); 
+  auto eigenvectors = std::get<1>(tup);
+
+  // check the eigenvalues, which are the same 
+  // on each process
+  double sumEigVals = 0.0; 
+  for(int i = 0; i < 2; i++) {
+    sumEigVals += eigenvalues[i]; 
+  }
+  EXPECT_EQ(sumEigVals, 0); 
+
+  // check the eigenvectors, 
+  // which themselves are distributed
+  double sumEigVecs = 0.0; 
+  for(int i = 0; i < 2; i++) {
+    for(int j = 0; j < 2; j++) {
+      if(eigenvectors.indecesAreLocal(i,j)) { 
+        sumEigVecs += eigenvectors(i,j);  
+      }
+    }  
+  }
+  mpi->allReduceSum(&sumEigVecs); 
+  EXPECT_EQ(sumEigVecs, 2*(1./sqrt(2)));
+}

--- a/test/activeBandStructureTest.cpp
+++ b/test/activeBandStructureTest.cpp
@@ -221,7 +221,6 @@ TEST(ActiveBandStructureTest, WindowFilter) {
   // pick a wavevector to check energies, eigenvectors, vels
   long ik = 12;
   auto ikIndex = WavevectorIndex(ik);
-  Point pointOTF = absOTF.getPoint(ik);
   double nb = absOTF.getNumBands(ikIndex);
 
   // get the values stored in each active bandstructure

--- a/test/mpi.cpp
+++ b/test/mpi.cpp
@@ -1,7 +1,7 @@
-#include "gtest/gtest.h"
-#include "mpiHelper.h"
-#include "eigen.h"
 #include "constants.h"
+#include "eigen.h"
+#include "mpiHelper.h"
+#include "gtest/gtest.h"
 
 TEST(MPITest, AllReduceSum) {
 
@@ -14,36 +14,36 @@ TEST(MPITest, AllReduceSum) {
   // the vector has only one element different from zero
   mpi->allReduceSum(&x);
   // now the vector should contain 1 everywhere
-  for ( double y : x ) {
+  for (double y : x) {
     EXPECT_EQ(y, 1.);
   }
 
   // test allReduceSum on a Eigen::MatrixXd ---------------------
-  Eigen::MatrixXd x2(size,size);
+  Eigen::MatrixXd x2(size, size);
   x2.setZero();
-  for ( long i=0; i<size; i++ ) {
-      x2(rank,i) = 1.;
+  for (long i = 0; i < size; i++) {
+    x2(rank, i) = 1.;
   }
   // the vector has only one element different from zero
   mpi->allReduceSum(&x2);
   // now the vector should contain 1 everywhere
-  for ( long i=0; i<size; i++ ) {
-      for ( long j=0; j<size; j++ ) {
-          EXPECT_EQ(x2(i,j), 1.);
-      }
+  for (long i = 0; i < size; i++) {
+    for (long j = 0; j < size; j++) {
+      EXPECT_EQ(x2(i, j), 1.);
+    }
   }
 
   // test allReduceSum on an Eigen::VectorXi ---------------------
   Eigen::VectorXi x3(size);
   x3.setZero();
-  for ( long i=0; i<size; i++ ) {
-      x3(rank,i) = 1;
+  for (long i = 0; i < size; i++) {
+    x3(rank, i) = 1;
   }
   // the vector has only one element different from zero
   mpi->allReduceSum(&x3);
   // now the vector should contain 1 everywhere
-  for ( long i=0; i<size; i++ ) {
-      EXPECT_EQ(x3(i), 1);
+  for (long i = 0; i < size; i++) {
+    EXPECT_EQ(x3(i), 1);
   }
 
   // std::vector test -------------------------------------------
@@ -52,40 +52,38 @@ TEST(MPITest, AllReduceSum) {
   // the vector has only one element different from zero
   mpi->allReduceSum(&x4);
   // now the vector should contain 1 everywhere
-  for ( std::complex<double> y : x4 ) {
+  for (std::complex<double> y : x4) {
     EXPECT_EQ(y, complexI);
   }
 
   // Test allReduce Sum on an Eigen::Tensor ------------------------
-  Eigen::Tensor<double, 5> x5(size,size,size,size,size);
+  Eigen::Tensor<double, 5> x5(size, size, size, size, size);
   x5.setZero();
 
   // fill every element with one
-  for ( long i=0; i<size; i++ ) {
-        for (long j=0; j<size; j++) {
-                for(long k=0; k<size; k++) {
-                        for(long m=0; m<size; m++) {
-                                for(long n=0; n<size; n++) {
-                                        x5(i,j,k,m,n) = i*j*k*m*n;
-                                } 
-                        }
-                }
+  for (long i = 0; i < size; i++) {
+    for (long j = 0; j < size; j++) {
+      for (long k = 0; k < size; k++) {
+        for (long m = 0; m < size; m++) {
+          for (long n = 0; n < size; n++) {
+            x5(i, j, k, m, n) = i * j * k * m * n;
+          }
         }
+      }
+    }
   }
   // the vector has only one element different from zero
   mpi->allReduceSum(&x5);
   // now the vector should contain nranks everywhere
-  for ( long i=0; i<size; i++ ) {
-        for (long j=0; j<size; j++) {
-                for(long k=0; k<size; k++) {
-                        for(long m=0; m<size; m++) {
-                                for(long n=0; n<size; n++) {
-                                        EXPECT_EQ(x5(i,j,k,m,n), i*k*j*m*n*mpi->getSize());
-                                } 
-                        } 
-                } 
+  for (long i = 0; i < size; i++) {
+    for (long j = 0; j < size; j++) {
+      for (long k = 0; k < size; k++) {
+        for (long m = 0; m < size; m++) {
+          for (long n = 0; n < size; n++) {
+            EXPECT_EQ(x5(i, j, k, m, n), i * k * j * m * n * mpi->getSize());
+          }
         }
+      }
+    }
   }
-
-
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -3,12 +3,20 @@
 #include "mpiHelper.h"
 #include "gtest/gtest.h"
 #include <Kokkos_Core.hpp>
+#include "io.h"
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
   initMPI();
   Kokkos::initialize(argc, argv);
+
+  // mute messages from other than root rank
+  ::testing::TestEventListeners& listeners =
+    ::testing::UnitTest::GetInstance()->listeners();
+  if (!mpi->mpiHead()) {
+    delete listeners.Release(listeners.default_result_printer());
+  }
 
   int errCode = RUN_ALL_TESTS();
 


### PR DESCRIPTION
### Summary:  
This pull request contains a handful of minor updates on #68. 

### Changes:
* Bugfix: There was an indexing mistake that affected eigenvector storage in the case where activeBandStructure was built with multiple cores and some points were filtered out. 
* Added a brief PMatrix google test, which just checks the eigenvectors and values of a diagonalized Pauli matrix are correct, and that the original matrix being diagonalized is not affected. (related to issue #65).
* Additional checks on the energies, velocities, and eigenvectors were added for the ActiveBandStructure test where the window is used to filter mesh points. 
* @cepellotti set up google tests to work with MPI. 