### PR TITLE
Improving the performance of the Tetrahedron method.

### DIFF
--- a/src/delta_function.cpp
+++ b/src/delta_function.cpp
@@ -98,13 +98,13 @@ double AdaptiveGaussianDeltaFunction::getSmearing(const double &energy,
 
 TetrahedronDeltaFunction::TetrahedronDeltaFunction(
     BaseBandStructure &fullBandStructure_)
-    : fullBandStructure(fullBandStructure_) {
-  auto fullPoints = fullBandStructure.getPoints();
+    : fullBandStructure(fullBandStructure_),
+      fullPoints(fullBandStructure_.getPoints()) {
   auto tup = fullPoints.getMesh();
   auto grid = std::get<0>(tup);
   auto offset = std::get<1>(tup);
   if (offset.norm() > 0.) {
-    Error("We didn't implement tetrahedra with offsets", 1);
+    Error("We didn't implement tetrahedra with offsets");
   }
   if (grid(0) < 1 || grid(1) < 1 || grid(2) < 1) {
     Error("Tetrahedron method initialized with invalid wavevector grid");
@@ -166,8 +166,8 @@ double TetrahedronDeltaFunction::getSmearing(const double &energy,
   int ik = std::get<0>(t).get();
   auto ibIndex = std::get<1>(t);
 
-  auto fullPoints = fullBandStructure.getPoints();
   // if the mesh is uniform, each k-point belongs to 6 tetrahedra
+
   auto kCoordinates = fullPoints.getPointCoordinates(ik, Points::crystalCoordinates);
 
   // in this tensor, we store the offset to find the vertices of the

--- a/src/delta_function.h
+++ b/src/delta_function.h
@@ -183,6 +183,7 @@ public:
 
 protected:
   BaseBandStructure &fullBandStructure;
+  Points fullPoints;
   int id = DeltaFunction::tetrahedron;
   Eigen::MatrixXd subCellShift;
   Eigen::MatrixXi vertices;


### PR DESCRIPTION
Turns out a lot of the time was spent initializing the Points class.
We now avoid it and the DoS is computed much faster.