### PR TITLE
Phonopy fix

### DIFF
--- a/src/delta_function.h
+++ b/src/delta_function.h
@@ -103,7 +103,8 @@ public:
    * @param bandStructure: mainly to see what mesh of points and crystal is
    * being used, and to prepare a suitable scaling of velocities.
    */
-  explicit AdaptiveGaussianDeltaFunction(BaseBandStructure &bandStructure);
+  explicit AdaptiveGaussianDeltaFunction(BaseBandStructure &bandStructure,
+                                         double broadeningCutoff_=0.0001 / energyRyToEv);
 
   /** Method to obtain the value of smearing.
    * @param energy: the energy difference.
@@ -125,6 +126,8 @@ public:
 
 protected:
   int id = DeltaFunction::adaptiveGaussian;
+
+  double broadeningCutoff;
 
   const double prefactor = 1.; // could be exposed to the user
   Eigen::Matrix3d qTensor;     // to normalize by the number of wavevectors.

--- a/src/statistics_sweep.cpp
+++ b/src/statistics_sweep.cpp
@@ -377,9 +377,11 @@ void StatisticsSweep::printInfo() {
   if (particle.isElectron()) {
     std::cout << "Fermi level: " << fermiLevel * energyRyToEv << " (eV)"
               << std::endl;
+    std::cout << "Index, temperature, chemical potential, doping concentration\n";
+  } else {
+    std::cout << "Index, temperature\n";
   }
 
-  std::cout << "Index, temperature, chemical potential, doping concentration\n";
 
   for (int iCalc = 0; iCalc < numCalculations; iCalc++) {
     double temp = infoCalculations(iCalc, 0);


### PR DESCRIPTION
Bugfixes:
1) fix a numerical instability happening for small adaptive broadening: now there is a minimum value of allowed broadening.
2) bugfix in the phono3py parser: sometimes phonopy uses Bohr, some others Angstrom. Now we parse for this info.