### PR TITLE
Updates so that Phoebe builds correctly with Intel Compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ if(Kokkos_ENABLE_CUDA)
     set(CMAKE_CXX_COMPILER ${CMAKE_CURRENT_SOURCE_DIR}/lib/kokkos/bin/nvcc_wrapper)
 endif()
 
+# set cmake version
 cmake_minimum_required(VERSION 3.16)
+# set cpp standard flags
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -33,7 +35,9 @@ option(OMP_AVAIL "Build with OMP" ON)
 option(HDF5_AVAIL "Build with HDF5" ON)
 option(HDF5_SERIAL "Force build to accomodate serial only HDF5, but still use MPI" OFF)
 option(BUILD_DOC "Build documentation" ON)
-
+if(OMP_AVAIL)
+  option(Kokkos_ENABLE_OPENMP "Use kokkos with omp" ON)
+endif()
 ############### SOURCE ###############
 
 FILE(GLOB_RECURSE SOURCE_FILES src src/*.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 
 cmake_minimum_required(VERSION 3.16)
 set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 project(Phoebe LANGUAGES C CXX Fortran VERSION 1.0)
 
@@ -97,7 +98,8 @@ if (MPI_AVAIL)
           elseif("${MPI_CXX_LIBRARIES}" MATCHES intel)
               find_library(BLACS_LIB NAMES mkl_blacs_intelmpi_lp64 PATHS ENV LD_LIBRARY_PATH)
           else()
-              message(FATAL_ERROR "Confused by MPI library when looking for BLACS.")
+              find_library(BLACS_LIB NAMES mkl_blacs_intelmpi_lp64 PATHS ENV LD_LIBRARY_PATH)
+              #message(FATAL_ERROR "Confused by MPI library when looking for BLACS.")
           endif()
           if(${BLACS_LIB} MATCHES NOTFOUND)
               message(FATAL_ERROR "Found Intel SCALAPACK but not BLACS")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,16 +19,12 @@ cmake ..
 make -j$(nproc)
 ```
 
-This will build a basic version of Phoebe, with MPI if available.
+This will build a basic version of Phoebe, with MPI and OpenMP if available.
+Often, you can receive additional acceleration by following the OMP env variable
+instructions from Kokkos:
 
-## OpenMP build
-```
-git submodule update --init
-mkdir build
-cd build
-cmake .. -DKokkos_ENABLE_OPENMP=ON -DOMP_AVAIL=ON
-make -j$(nproc)
-```
+  "In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
+  For best performance with OpenMP 3.1 set OMP_PROC_BIND=true."
 
 ## CUDA build
 ```

--- a/doc/sphinx/source/installation.rst
+++ b/doc/sphinx/source/installation.rst
@@ -52,6 +52,10 @@ where you should substitute ``nproc`` with the number of cores available for par
 
 CMake will inspect the paths found in the environmental variable ``LD_LIBRARY_PATH`` to verify the existence of an installed copy of the ScaLAPACK library and link it. If not found, the installation will download and compile a copy of ScaLAPACK.
 
+.. note::
+   Phoebe often uses OMP through Kokkos. For best performance, you may want to follow the advice from Kokkos regarding OMP env variables:
+   "In general, for best performance with OpenMP 4.0 or better set ``OMP_PROC_BIND=spread`` and ``OMP_PLACES=threads``. For best performance with OpenMP 3.1 set OMP_PROC_BIND=true"
+
 HDF5 build
 ^^^^^^^^^^
 
@@ -72,14 +76,10 @@ perform parallel read/write operations, they must build Phoebe using the ``-DHDF
    When building with Intel compilers, it seems sometimes it's necessary to set compiler flags to CC=mpiicc, CXX=mpiicpc, and FC=mpiifort explicitly. Try this if you have issues.
 
 
-OpenMP build
-^^^^^^^^^^^^
-Use flags ``DOMP_AVAIL`` and ``DKokkos_ENABLE_OPENMP`` to toggle OpenMP functionally, with the first flag controlling typical OMP use, and the second applying to OMP functionality provided through Kokkos. The default is ``DOMP_AVAIL=ON`` and ``DKokkos_ENABLE_OPENMP=OFF``.
-::
+Build without OpenMP (Not recommended)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Use flags ``DOMP_AVAIL`` and ``DKokkos_ENABLE_OPENMP`` to toggle OpenMP functionally, with the first flag controlling typical OMP use, and the second applying to OMP functionality provided through Kokkos. The default is ``DOMP_AVAIL=ON`` and ``DKokkos_ENABLE_OPENMP=ON``. Setting ``DOMP_AVAIL=OFF`` will disable the use of OMP and OMP through Kokkos, though performance will take a hit if you must do this.
 
-  # CMake flags to enable OMP
-  cmake .. -DKokkos_ENABLE_OPENMP=ON -DOMP_AVAIL=ON
-  make -j$(nproc)
 
 Kokkos build (For GPU use)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/sphinx/source/installation.rst
+++ b/doc/sphinx/source/installation.rst
@@ -68,6 +68,9 @@ perform parallel read/write operations, they must build Phoebe using the ``-DHDF
 
    cmake .. -DCMAKE_CXX_STANDARD_LIBRARIES="-L/usr/lib/x86_64-linux-gnu/hdf5/openmpi/" -DCMAKE_CXX_FLAGS="-I/usr/include/hdf5/openmpi/"
 
+.. note::
+   When building with Intel compilers, it seems sometimes it's necessary to set compiler flags to CC=mpiicc, CXX=mpiicpc, and FC=mpiifort explicitly. Try this if you have issues.
+
 
 OpenMP build
 ^^^^^^^^^^^^

--- a/src/algebra/Matrix.cpp
+++ b/src/algebra/Matrix.cpp
@@ -39,7 +39,7 @@ Matrix<std::complex<double>>::diagonalize() {
     eigenvalues = std::get<0>(tup);
     eigenvectors.mat = &(std::get<1>(tup));
   }
-  return {eigenvalues, eigenvectors};
+  return std::make_tuple(eigenvalues, eigenvectors);
 }
 
 // Diagonalize for real double symmetric matrix
@@ -59,7 +59,7 @@ std::tuple<std::vector<double>, Matrix<double>> Matrix<double>::diagonalize() {
     eigenvalues = std::get<0>(tup);
     eigenvectors.mat = &(std::get<1>(tup));
   }
-  return {eigenvalues, eigenvectors};
+  return std::make_tuple(eigenvalues, eigenvectors);
 }
 
 // Explicit specialization of norm for doubles

--- a/src/algebra/PMatrix.cpp
+++ b/src/algebra/PMatrix.cpp
@@ -151,7 +151,7 @@ ParallelMatrix<double>::diagonalize() {
   delete[] work;
   // note that the scattering matrix now has different values
 
-  return {eigenvalues_, eigenvectors};
+  return std::make_tuple(eigenvalues_, eigenvectors);
 }
 
 template <>
@@ -206,7 +206,7 @@ ParallelMatrix<std::complex<double>>::diagonalize() {
   delete[] rwork;
   // note that the scattering matrix now has different values
 
-  return {eigenvalues_, eigenvectors};
+  return std::make_tuple(eigenvalues_, eigenvectors);
 }
 
 #endif  // MPI_AVAIL

--- a/src/algebra/PMatrix.h
+++ b/src/algebra/PMatrix.h
@@ -490,7 +490,7 @@ std::tuple<int,int> ParallelMatrix<T>::local2Global(const int& i, const int& j) 
   int iZero = 0;
   int ig = indxl2g_( &il, &blockSizeRows_, &myBlasRow_, &iZero, &numBlasRows_ );
   int jg = indxl2g_( &jl, &blockSizeCols_, &myBlasCol_, &iZero, &numBlasCols_ );
-  return {ig,jg};
+  return std::make_tuple(ig,jg);
 }
 
 template <typename T>
@@ -508,7 +508,7 @@ std::tuple<int, int> ParallelMatrix<T>::local2Global(const int& k) const {
 
   //int ig = indxl2g_( &il, &blockSizeRows_, &myBlasRow_, 0, &numBlasRows_ );
   //int jg = indxl2g_( &jl, &blockSizeCols_, &myBlasCol_, 0, &numBlasCols_ );
-  //return {ig,jg};
+  //return std::make_tuple(ig,jg);
 
   // now we can convert local row/col indices into global indices
 
@@ -521,7 +521,7 @@ std::tuple<int, int> ParallelMatrix<T>::local2Global(const int& k) const {
   int x_j = j % blockSizeCols_;  // where within that block
   // global col
   int J = (l_j * numBlasCols_ + myBlasCol_) * blockSizeCols_ + x_j;
-  return {I, J};
+  return std::make_tuple(I, J);
 }
 
 template <typename T>

--- a/src/algebra/SMatrix.cpp
+++ b/src/algebra/SMatrix.cpp
@@ -61,7 +61,7 @@ SerialMatrix<std::complex<double>>::diagonalize() {
   if (info != 0) {
     Error("ZHEEV failed in SMatrix.", info);
   }
-  return {eigenvalues, eigenvectors};
+  return std::make_tuple(eigenvalues, eigenvectors);
 }
 
 // Diagonalize for real double symmetric matrix
@@ -86,7 +86,7 @@ std::tuple<std::vector<double>, SerialMatrix<double>> SerialMatrix<double>::diag
   if (info != 0) {
     Error("DSYEV failed in SMatrix.", info);
   }
-  return {eigenvalues, eigenvectors};
+  return std::make_tuple(eigenvalues, eigenvectors);
 }
 
 // Explicit specialization of norm for doubles

--- a/src/algebra/SMatrix.h
+++ b/src/algebra/SMatrix.h
@@ -297,7 +297,7 @@ std::tuple<int, int> SerialMatrix<T>::local2Global(const int& k) {
   if(numRows_ == 0) Error("attempted to div by zero in l2g");
   int j = k / numRows_;
   int i = k - j * numRows_;
-  return {i, j};
+  return std::make_tuple(i, j);
 }
 
 // Indexing to set up the matrix in col major format

--- a/src/apps/dos_app.cpp
+++ b/src/apps/dos_app.cpp
@@ -168,7 +168,7 @@ std::tuple<std::vector<double>, std::vector<double>> calcDOS(
   // all processes send their data to be gathered into dos/eneTotal
   mpi->gatherv(&energies, &eneTotal);
   mpi->gatherv(&dos, &dosTotal);
-  return {eneTotal, dosTotal};
+  return std::make_tuple(eneTotal, dosTotal);
 
 }
 

--- a/src/apps/elph_qe_to_phoebe_app.cpp
+++ b/src/apps/elph_qe_to_phoebe_app.cpp
@@ -167,7 +167,7 @@ ElPhQeToPhoebeApp::readChunkGFromQE(const int& iqIrr, Context &context,
     }
   }
 
-  return {gStar, phononEigenvectorsStar, phononEnergiesStar, qStar};
+  return std::make_tuple(gStar, phononEigenvectorsStar, phononEnergiesStar, qStar);
 }
 
 // read g, which is written to file on all k, q points
@@ -280,7 +280,7 @@ ElPhQeToPhoebeApp::readGFromQEFile(Context &context, const int &numModes,
   mpi->bcast(&phEigenvectors);
   mpi->bcast(&phEnergies);
 
-  return {gFull, phEigenvectors, phEnergies};
+  return std::make_tuple(gFull, phEigenvectors, phEnergies);
 }
 
 std::tuple<Eigen::Vector3i, Eigen::Vector3i, Eigen::MatrixXd, Eigen::MatrixXd,
@@ -372,6 +372,6 @@ ElPhQeToPhoebeApp::readQEPhoebeHeader(Crystal &crystal,
   mpi->bcast(&kGridFull);
   mpi->bcast(&energies);
 
-  return {qMesh,         kMesh,      kGridFull,    qGridFull, energies,
-          numIrrQPoints, numQEBands, numElectrons, numSpin};
+  return std::make_tuple(qMesh,         kMesh,      kGridFull,    qGridFull, energies,
+          numIrrQPoints, numQEBands, numElectrons, numSpin);
 }

--- a/src/apps/transport_epa_app.cpp
+++ b/src/apps/transport_epa_app.cpp
@@ -164,7 +164,7 @@ TransportEpaApp::calcEnergyProjVelocity(Context &context,
   mpi->allReduceSum(&energyProjVelocity);
   mpi->allReduceSum(&dos);
   loopPrint.close();
-  return {energyProjVelocity, dos};
+  return std::make_tuple(energyProjVelocity, dos);
 }
 
 VectorEPA TransportEpaApp::getScatteringRates(

--- a/src/bands/active_bandstructure.cpp
+++ b/src/bands/active_bandstructure.cpp
@@ -139,7 +139,7 @@ ActiveBandStructure::getIndex(const int &is) {
   auto ib = std::get<1>(tup);
   WavevectorIndex ikk(ik);
   BandIndex ibb(ib);
-  return {ikk, ibb};
+  return std::make_tuple(ikk, ibb);
 }
 
 std::tuple<WavevectorIndex, BandIndex>
@@ -309,7 +309,7 @@ int ActiveBandStructure::bloch2Comb(const int &ik, const int &ib) {
 }
 
 std::tuple<int, int> ActiveBandStructure::comb2Bloch(const int &is) {
-  return {auxBloch2Comb(is, 0), auxBloch2Comb(is, 1)};
+  return std::make_tuple(auxBloch2Comb(is, 0), auxBloch2Comb(is, 1));
 }
 
 int ActiveBandStructure::bteBloch2Comb(const int &ik, const int &ib) {
@@ -317,7 +317,7 @@ int ActiveBandStructure::bteBloch2Comb(const int &ik, const int &ib) {
 }
 
 std::tuple<int, int> ActiveBandStructure::bteComb2Bloch(const int &iBte) {
-  return {bteAuxBloch2Comb(iBte, 0), bteAuxBloch2Comb(iBte, 1)};
+  return std::make_tuple(bteAuxBloch2Comb(iBte, 0), bteAuxBloch2Comb(iBte, 1));
 }
 
 void ActiveBandStructure::buildIndices() {
@@ -397,7 +397,7 @@ ActiveBandStructure::builder(Context &context, HarmonicHamiltonian &h0,
 
     StatisticsSweep s = activeBandStructure.buildAsPostprocessing(
         context, points_, h0, withEigenvectors, withVelocities);
-    return {activeBandStructure, s};
+    return std::make_tuple(activeBandStructure, s);
 
   }
   // but phonons are default built OTF.
@@ -413,7 +413,7 @@ ActiveBandStructure::builder(Context &context, HarmonicHamiltonian &h0,
                                       withVelocities);
 
     StatisticsSweep statisticsSweep(context);
-    return {activeBandStructure, statisticsSweep};
+    return std::make_tuple(activeBandStructure, statisticsSweep);
   }
 }
 

--- a/src/bands/bandstructure.cpp
+++ b/src/bands/bandstructure.cpp
@@ -116,7 +116,7 @@ std::tuple<WavevectorIndex, BandIndex> FullBandStructure::getIndex(
   int ib = is - ik * numBands;
   auto ikk = WavevectorIndex(ik);
   auto ibb = BandIndex(ib);
-  return {ikk, ibb};
+  return std::make_tuple(ikk, ibb);
 }
 
 std::tuple<WavevectorIndex, BandIndex> FullBandStructure::getIndex(

--- a/src/bands/window.cpp
+++ b/src/bands/window.cpp
@@ -72,7 +72,7 @@ std::tuple<std::vector<double>, std::vector<int>> Window::apply(
     std::vector<int> bandExtrema(2);
     bandExtrema[0] = 0;
     bandExtrema[1] = numBands - 1;
-    return {filteredEnergies, bandExtrema};
+    return std::make_tuple(filteredEnergies, bandExtrema);
   }
 }
 
@@ -97,7 +97,7 @@ std::tuple<std::vector<double>, std::vector<int>> Window::internalPopWindow(
     bandsExtrema.push_back(bandsIndices[0]);
     bandsExtrema.push_back(bandsIndices[bandsIndices.size() - 1]);
   } // or return empty lists if nothing is found
-  return {filteredEnergies, bandsExtrema};
+  return std::make_tuple(filteredEnergies, bandsExtrema);
 }
 
 std::tuple<std::vector<double>, std::vector<int>> Window::internalEnWindow(
@@ -119,7 +119,7 @@ std::tuple<std::vector<double>, std::vector<int>> Window::internalEnWindow(
     bandsExtrema.push_back(bandsIndices[0]);
     bandsExtrema.push_back(bandsIndices[bandsIndices.size() - 1]);
   } // or return empty lists if nothing is found
-  return {filteredEnergies, bandsExtrema};
+  return std::make_tuple(filteredEnergies, bandsExtrema);
 }
 
 int Window::getMethodUsed() const {

--- a/src/bte/helper_3rd_state.cpp
+++ b/src/bte/helper_3rd_state.cpp
@@ -193,7 +193,7 @@ Helper3rdState::get(Point &point1, Point &point2, const int &thisCase) {
       }
     }
 
-    return {q3, energies3, nb3, eigenVectors3, v3s, bose3Data};
+    return std::make_tuple(q3, energies3, nb3, eigenVectors3, v3s, bose3Data);
 
   } else {
     // otherwise, q3 doesn't fall into the same grid
@@ -221,7 +221,7 @@ Helper3rdState::get(Point &point1, Point &point2, const int &thisCase) {
     }
 
     int nb3 = int(energies3.size());
-    return {q3, energies3, nb3, eigenVectors3, v3s, bose3Data};
+    return std::make_tuple(q3, energies3, nb3, eigenVectors3, v3s, bose3Data);
   }
 }
 

--- a/src/bte/helper_el_scattering.cpp
+++ b/src/bte/helper_el_scattering.cpp
@@ -265,7 +265,7 @@ std::tuple<Eigen::Vector3d, Eigen::VectorXd, int, Eigen::MatrixXcd,
     }
     Eigen::VectorXcd polarData = mappedPolarData.at(iq3);
 
-    return {q3, energies3, nb3, eigenVectors3, v3s, bose3Data, polarData};
+    return std::make_tuple(q3, energies3, nb3, eigenVectors3, v3s, bose3Data, polarData);
 
   } else {
     // otherwise, q3 doesn't fall into the same grid
@@ -281,7 +281,7 @@ std::tuple<Eigen::Vector3d, Eigen::VectorXd, int, Eigen::MatrixXcd,
     Eigen::VectorXcd polarData = cachePolarData[ik2Counter];
     int nb3 = int(energies3.size());
 
-    return {q3, energies3, nb3, eigenVectors3, v3s, bose3Data, polarData};
+    return std::make_tuple(q3, energies3, nb3, eigenVectors3, v3s, bose3Data, polarData);
   }
 }
 

--- a/src/bte/scattering.cpp
+++ b/src/bte/scattering.cpp
@@ -728,7 +728,7 @@ ScatteringMatrix::diagonalize() {
     eigenValues(is) = eigenvalues[is];
   }
 
-  return {eigenValues, eigenvectors};
+  return std::make_tuple(eigenValues, eigenvectors);
 }
 
 std::vector<std::tuple<std::vector<int>, int>>
@@ -963,9 +963,9 @@ std::tuple<BteIndex, CartIndex>
 ScatteringMatrix::getSMatrixIndex(const int &iMat) {
   if (context.getUseSymmetries()) {
     auto t = decompress2Indices(iMat, numStates, 3);
-    return {BteIndex(std::get<0>(t)), CartIndex(std::get<1>(t))};
+    return std::make_tuple(BteIndex(std::get<0>(t)), CartIndex(std::get<1>(t)));
   } else {
-    return {BteIndex(iMat), CartIndex(0)};
+    return std::make_tuple(BteIndex(iMat), CartIndex(0));
   }
 }
 

--- a/src/bte/vector_bte.cpp
+++ b/src/bte/vector_bte.cpp
@@ -323,7 +323,7 @@ VectorBTE::loc2Glob(
   auto imu = std::get<0>(tup);
   auto it = std::get<1>(tup);
   auto iDim = std::get<2>(tup);
-  return {ChemPotIndex(imu), TempIndex(it), CartIndex(iDim)};
+  return std::make_tuple(ChemPotIndex(imu), TempIndex(it), CartIndex(iDim));
 }
 
 void VectorBTE::setConst(const double &constant) {

--- a/src/bte/vector_bte.cpp
+++ b/src/bte/vector_bte.cpp
@@ -207,16 +207,23 @@ VectorBTE VectorBTE::operator*(ParallelMatrix<double> &matrix) {
   auto allLocalStates = matrix.getAllLocalStates();
   size_t numAllLocalStates = allLocalStates.size();
 
-#pragma omp declare reduction (+: VectorBTE: omp_out.data=omp_out.data+omp_in.data)\
- initializer(omp_priv=VectorBTE(omp_orig.statisticsSweep, \
-                                omp_orig.bandStructure, omp_orig.dimensionality))
-#pragma omp parallel for reduction(+ : newPopulation)
-  for (size_t iTup=0; iTup<numAllLocalStates; iTup++) {
-    auto tup = allLocalStates[iTup];
-    auto i = std::get<0>(tup);
-    auto j = std::get<1>(tup);
-    for (int iCalc = 0; iCalc < numCalculations; iCalc++) {
-      newPopulation.data(iCalc, j) += data(iCalc, i) * matrix(i, j); // -5e-12
+  #pragma omp parallel
+  {
+    Eigen::MatrixXd dataPrivate = newPopulation.data;
+#pragma omp for
+    for (size_t iTup=0; iTup<numAllLocalStates; iTup++) {
+      auto tup = allLocalStates[iTup];
+      auto i = std::get<0>(tup);
+      auto j = std::get<1>(tup);
+      for (int iCalc = 0; iCalc < numCalculations; iCalc++) {
+	dataPrivate(iCalc, j) += data(iCalc, i) * matrix(i, j);
+      }
+    }
+#pragma omp critical
+    for (int j=0; j<data.cols(); ++j) {
+      for (int iCalc = 0; iCalc < numCalculations; iCalc++) {
+	newPopulation.data(iCalc, j) += dataPrivate(iCalc, j);
+      }
     }
   }
   mpi->allReduceSum(&newPopulation.data);

--- a/src/bte/vector_epa.cpp
+++ b/src/bte/vector_epa.cpp
@@ -219,7 +219,7 @@ VectorEPA::loc2Glob(
   auto imu = std::get<0>(tup);
   auto it = std::get<1>(tup);
   auto iDim = std::get<2>(tup);
-  return {ChemPotIndex(imu), TempIndex(it), CartIndex(iDim)};
+  return std::make_tuple(ChemPotIndex(imu), TempIndex(it), CartIndex(iDim));
 }
 
 // get/set operator

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -129,7 +129,7 @@ std::tuple<int,double> parseDoubleVectorComponent(std::string line) {
 
   int idx = std::stoi(part1);
   double val = std::stod(part2);
-  return {idx,val};
+  return std::make_tuple(idx,val);
 }
 
 
@@ -276,7 +276,7 @@ parseCrystal(std::vector<std::string> &lines) {
     counter++;
   }
   atomicPositions /= distanceBohrToAng;
-  return {atomicPositions, atomicSpecies, speciesNames};
+  return std::make_tuple(atomicPositions, atomicSpecies, speciesNames);
 }
 
 /** Reads the block with the information on the path of points in the
@@ -324,7 +324,7 @@ parsePathExtrema(std::vector<std::string> &lines) {
 
     i++;
   }
-  return {pathLabels, pathExtrema};
+  return std::make_tuple(pathLabels, pathExtrema);
 }
 
 /** Parse an input block (e.g. for crystal or points path).
@@ -341,7 +341,7 @@ parseBlockNameValue(const std::vector<std::string> &lines,
   if (!patternInString(line, "begin")) {
     std::string empty1;
     std::vector<std::string> empty2;
-    return {empty1, empty2};
+    return std::make_tuple(empty1, empty2);
   } else {
     std::string pattern = "begin";
     std::size_t found = line.find(pattern);
@@ -353,7 +353,7 @@ parseBlockNameValue(const std::vector<std::string> &lines,
       }
       val.push_back(lines[i]);
     }
-    return {blockName, val};
+    return std::make_tuple(blockName, val);
   }
 }
 
@@ -408,7 +408,7 @@ parseParameterNameValue(const std::string &line) {
   if (s2 != s) {
     val = line.substr(position2 + 1, line.size());
   }
-  return {s2, val};
+  return std::make_tuple(s2, val);
 }
 
 void Context::setupFromInput(const std::string &fileName) {

--- a/src/crystal.cpp
+++ b/src/crystal.cpp
@@ -455,7 +455,7 @@ Crystal::buildWignerSeitzVectors(const Eigen::Vector3i &grid,
   positionVectors.col(0) = tmpV1;
   positionVectors.col(originIndex) = tmpV2;
 
-  return {positionVectors, positionDegeneracies};
+  return std::make_tuple(positionVectors, positionDegeneracies);
 }
 
 std::tuple<Eigen::MatrixXd, Eigen::Tensor<double, 3>>
@@ -635,5 +635,5 @@ Crystal::buildWignerSeitzVectorsWithShift(const Eigen::Vector3i &grid,
       }
     }
   }
-  return {bravaisVectors, degeneracies};
+  return std::make_tuple(bravaisVectors, degeneracies);
 }

--- a/src/harmonic/electron_h0_fourier.cpp
+++ b/src/harmonic/electron_h0_fourier.cpp
@@ -117,7 +117,7 @@ ElectronH0Fourier::diagonalize(Point &point) {
   auto tup = diagonalizeFromCoordinates(coordinates);
   auto energies = std::get<0>(tup);
   auto eigenVectors = std::get<1>(tup);
-  return {energies, eigenVectors};
+  return std::make_tuple(energies, eigenVectors);
 }
 
 std::tuple<Eigen::VectorXd, Eigen::MatrixXcd>
@@ -128,7 +128,7 @@ ElectronH0Fourier::diagonalizeFromCoordinates(Eigen::Vector3d &wavevector) {
   for (int ib = 0; ib < numBands; ib++) {
     energies(ib) = getEnergyFromCoordinates(wavevector, ib);
   }
-  return {energies, eigenVectors};
+  return std::make_tuple(energies, eigenVectors);
 }
 
 Eigen::Tensor<std::complex<double>, 3>

--- a/src/harmonic/electron_h0_wannier.cpp
+++ b/src/harmonic/electron_h0_wannier.cpp
@@ -88,7 +88,7 @@ ElectronH0Wannier::diagonalize(Point &point) {
   // note: the eigenvector matrix is the unitary transformation matrix U
   // from the Bloch to the Wannier gauge.
 
-  return {energies, eigenvectors};
+  return std::make_tuple(energies, eigenvectors);
 }
 
 std::tuple<Eigen::VectorXd, Eigen::MatrixXcd>
@@ -136,7 +136,7 @@ ElectronH0Wannier::diagonalizeFromCoordinates(Eigen::Vector3d &k) {
   Eigen::VectorXd energies = eigenSolver.eigenvalues();
   Eigen::MatrixXcd eigenvectors = eigenSolver.eigenvectors();
 
-  return {energies, eigenvectors};
+  return std::make_tuple(energies, eigenvectors);
 }
 
 Eigen::Tensor<std::complex<double>, 3>

--- a/src/harmonic/phonon_h0.cpp
+++ b/src/harmonic/phonon_h0.cpp
@@ -195,7 +195,7 @@ PhononH0::diagonalize(Point &point) {
   auto tup = diagonalizeFromCoordinates(q, withMassScaling);
   auto energies = std::get<0>(tup);
   auto eigenvectors = std::get<1>(tup);
-  return {energies, eigenvectors};
+  return std::make_tuple(energies, eigenvectors);
 }
 
 std::tuple<Eigen::VectorXd, Eigen::MatrixXcd>
@@ -243,7 +243,7 @@ PhononH0::diagonalizeFromCoordinates(Eigen::Vector3d &q,
     }
   }
 
-  return {energies, eigenvectors};
+  return std::make_tuple(energies, eigenvectors);
 }
 
 FullBandStructure PhononH0::populate(Points &points, bool &withVelocities,
@@ -616,7 +616,7 @@ PhononH0::dynDiagonalize(Eigen::Tensor<std::complex<double>, 4> &dyn) {
   }
   Eigen::MatrixXcd eigenvectors = eigenSolver.eigenvectors();
 
-  return {energies, eigenvectors};
+  return std::make_tuple(energies, eigenvectors);
 }
 
 Eigen::Tensor<std::complex<double>, 3>

--- a/src/interaction/interaction_3ph.cpp
+++ b/src/interaction/interaction_3ph.cpp
@@ -414,7 +414,7 @@ Interaction3Ph::getCouplingsSquared(
       }
     }
   }
-  return {couplingPlus_e, couplingMins_e};
+  return std::make_tuple(couplingPlus_e, couplingMins_e);
 }
 
 int Interaction3Ph::estimateNumBatches(const int &nq1, const int &nb2) {

--- a/src/interaction/interaction_elph_parsing.cpp
+++ b/src/interaction/interaction_elph_parsing.cpp
@@ -260,9 +260,9 @@ std::tuple<int, int, int, Eigen::MatrixXd, Eigen::MatrixXd, std::vector<size_t>,
     Error("Issue reading elph Wannier representation from hdf5.");
   }
 
-  return {numElBands, numPhBands, totalNumElBravaisVectors, elBravaisVectors_,
+  return std::make_tuple(numElBands, numPhBands, totalNumElBravaisVectors, elBravaisVectors_,
           phBravaisVectors_, localElVectors, elBravaisVectorsDegeneracies_,
-          phBravaisVectorsDegeneracies_};
+          phBravaisVectorsDegeneracies_);
 }
 
 // specific parse function for the case where parallel HDF5 is available

--- a/src/mpi/mpiController.cpp
+++ b/src/mpi/mpiController.cpp
@@ -221,7 +221,7 @@ MPIcontroller::workDivHelper(size_t numTasks) const {
     workDivs[i] = workDivisionTails[i] - workDivisionHeads[i];
   }
 
-  return {workDivs, workDivisionHeads};
+  return std::make_tuple(workDivs, workDivisionHeads);
 }
 
 #ifdef MPI_AVAIL
@@ -240,6 +240,6 @@ std::tuple<MPI_Comm,int> MPIcontroller::decideCommunicator(const int& communicat
   } else {
     Error("Invalid pool communicator");
   }
-  return {comm, broadcaster};
+  return std::make_tuple(comm, broadcaster);
 }
 #endif

--- a/src/observable/observable.cpp
+++ b/src/observable/observable.cpp
@@ -49,7 +49,7 @@ std::tuple<ChemPotIndex, TempIndex> Observable::loc2Glob(const int &i) const {
   auto tup = decompress2Indices(i, numChemPots, numTemps);
   auto imu = std::get<0>(tup);
   auto it = std::get<1>(tup);
-  return {ChemPotIndex(imu), TempIndex(it)};
+  return std::make_tuple(ChemPotIndex(imu), TempIndex(it));
 }
 
 Observable Observable::operator-(const Observable &that) {

--- a/src/parser/ifc3_parser.cpp
+++ b/src/parser/ifc3_parser.cpp
@@ -370,7 +370,7 @@ reorderDynamicalMatrix(
     }// close nb loop
   }  // close na loop
 
-  return {bravaisVectors, weights, bravaisVectors, weights};
+  return std::make_tuple(bravaisVectors, weights, bravaisVectors, weights);
 }
 
 Interaction3Ph IFC3Parser::parseFromPhono3py(Context &context,

--- a/src/parser/phonopy_input_parser.cpp
+++ b/src/parser/phonopy_input_parser.cpp
@@ -519,6 +519,6 @@ std::tuple<Crystal, PhononH0> PhonopyParser::parsePhHarmonic(Context &context) {
   PhononH0 dynamicalMatrix(crystal, dielectricMatrix, bornCharges,
                            forceConstants, context.getSumRuleFC2());
 
-  return {crystal, dynamicalMatrix};
+  return std::make_tuple(crystal, dynamicalMatrix);
 #endif
 }

--- a/src/parser/qe_input_parser.cpp
+++ b/src/parser/qe_input_parser.cpp
@@ -548,7 +548,7 @@ std::tuple<Crystal, PhononH0> QEParser::parsePhHarmonic(Context &context) {
   PhononH0 dynamicalMatrix(crystal, dielectricMatrix, bornCharges,
                            forceConstants, context.getSumRuleFC2());
 
-  return {crystal, dynamicalMatrix};
+  return std::make_tuple(crystal, dynamicalMatrix);
 }
 
 std::tuple<Crystal, ElectronH0Fourier>
@@ -771,7 +771,7 @@ QEParser::parseElHarmonicFourier(Context &context) {
   ElectronH0Fourier electronH0(crystal, coarsePoints, coarseBandStructure,
                                fourierCutoff);
 
-  return {crystal, electronH0};
+  return std::make_tuple(crystal, electronH0);
 }
 
 std::pair<Eigen::Tensor<double, 3>,
@@ -841,7 +841,7 @@ std::pair<Eigen::Tensor<double, 3>,
     }
   }
 
-  return {degeneracyShifts, phaseShifts};
+  return std::make_pair(degeneracyShifts, phaseShifts);
 }
 
 std::tuple<Crystal, ElectronH0Wannier>
@@ -1000,7 +1000,7 @@ QEParser::parseElHarmonicWannier(Context &context, Crystal *inCrystal) {
   }
 
   if (inCrystal != nullptr) {
-    return {*inCrystal, electronH0};
+    return std::make_tuple(*inCrystal, electronH0);
   } else {
     Eigen::MatrixXd atomicPositions = context.getInputAtomicPositions();
     Eigen::VectorXi atomicSpecies = context.getInputAtomicSpecies();
@@ -1017,6 +1017,6 @@ QEParser::parseElHarmonicWannier(Context &context, Crystal *inCrystal) {
     Crystal crystal(context, directUnitCell, atomicPositions, atomicSpecies,
                     speciesNames, speciesMasses);
     crystal.print();
-    return {crystal, electronH0};
+    return std::make_tuple(crystal, electronH0);
   }
 }

--- a/src/points.cpp
+++ b/src/points.cpp
@@ -312,7 +312,7 @@ std::pair<int,int> internalPointsBinarySearch(const Eigen::MatrixXd& pointsList,
                                        direction);
 
   if (id == -1) { // point was not found
-    return {-1, -1};
+    return std::make_pair(-1, -1);
   }
 
   // note: the binary search per-se requires unique elements
@@ -349,7 +349,7 @@ std::pair<int,int> internalPointsBinarySearch(const Eigen::MatrixXd& pointsList,
       break; // exit if point is different
     }
   }
-  return {idxMin, idxMax};
+  return std::make_pair(idxMin, idxMax);
 }
 
 /** Binary search algorithm to look for a vector in a list of vector.
@@ -551,7 +551,7 @@ void Points::setMesh(const Eigen::Vector3i &mesh_,
 }
 
 std::tuple<Eigen::Vector3i, Eigen::Vector3d> Points::getMesh() {
-  return {mesh, offset};
+  return std::make_tuple(mesh, offset);
 }
 
 std::tuple<Eigen::Vector3i, Eigen::Vector3d>
@@ -616,7 +616,7 @@ Points::findMesh(const Eigen::Matrix<double, 3, Eigen::Dynamic> &testPoints) {
   if (numTestPoints != mesh_(0) * mesh_(1) * mesh_(2)) {
     Error("Mesh of points seems incomplete");
   }
-  return {mesh_, offset_};
+  return std::make_tuple(mesh_, offset_);
 }
 
 ////////////////////////////////////////////////////////////////
@@ -949,11 +949,11 @@ Points::getRotationToIrreducible(const Eigen::Vector3d &x, const int &basis) {
           rotationMatricesCartesian[mapEquivalenceRotationIndex(ik)].inverse();
     }
     // also, we add the index of the irreducible point to which x is mapped
-    return {equiv(ik), rot};
+    return std::make_tuple(equiv(ik), rot);
   } else {
     Eigen::Matrix3d identity;
     identity.setIdentity();
-    return {ik, identity};
+    return std::make_tuple(ik, identity);
   }
 }
 

--- a/src/statistics_sweep.cpp
+++ b/src/statistics_sweep.cpp
@@ -96,7 +96,7 @@ StatisticsSweep::StatisticsSweep(Context &context,
       }
       occupiedStates = 0.;
 #pragma omp parallel for reduction(+ : occupiedStates)
-      for (double &x : energies) {
+      for (int is = 0; is < fullBandStructure->getNumStates(); is++) {
         if (x < fermiLevel) {
           occupiedStates += 1.;
         }

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -23,7 +23,7 @@ std::tuple<int, int, int> decompress3Indices(const int &iTot, const int &size1,
   int i2 = remainder / size3;
   remainder -= i2 * size3;
   int i3 = remainder;
-  return {i1, i2, i3};
+  return std::make_tuple(i1, i2, i3);
 }
 
 int compress2Indices(const int &i1, const int &i2, const int &size1,
@@ -37,7 +37,7 @@ std::tuple<int, int> decompress2Indices(const int &iTot, const int &size1,
   (void)size1;
   int i1 = iTot / size2;
   int i2 = iTot - i1 * size2;
-  return {i1, i2};
+  return std::make_tuple(i1, i2);
 }
 
 std::tuple<double, double> memoryUsage() {
@@ -71,7 +71,7 @@ std::tuple<double, double> memoryUsage() {
               << resident_set/1024./1024. << " (GB)\n" << std::endl;
   }
 
-  return {vm_usage, resident_set};
+  return std::make_tuple(vm_usage, resident_set);
 }
 
 double findMaxRelativeDifference(const Eigen::Tensor<double,3> &x,


### PR DESCRIPTION
In this branch, we make various fixes to Phoebe so that it will build with Intel compilers.

### The main fixes are:
 *   converting return {item1,item2...} statements to return std::make_tuple(item1,item2...);
 *  replacing three OMP loops which used reduction in statisticsSweep
 * replacing OMP loops which were accessing protected class objects
 *   updating CMakeLists to enforce the c++14 standard properly in the Intel case
 *  Update the Intel build instructions in the docs

### Kokkos with OMP now default:

Additionally, we now make using Kokkos with OMP the default behavior of Phoebe, so that users are not accidentally slowed down if they forget the Kokkos_ENABLE_OMP flag during cmake.