### PR TITLE
Alleviate bottlenecks related to the filtering of points

### DIFF
--- a/src/points.cpp
+++ b/src/points.cpp
@@ -866,15 +866,16 @@ void Points::setIrreduciblePoints(
   // this allows us to map (ikRed in fullPoints) -> (ikIrr in the irrPoints)
   // basically the inverse of mapIrrToRedList
   mapReducibleToIrreducibleList = Eigen::VectorXi::Zero(numPoints);
+
+  // make a vector copy of mI2R for binary search
+  std::vector<int> mI2R(mapIrreducibleToReducibleList.data(),
+                   mapIrreducibleToReducibleList.data()
+                        + mapIrreducibleToReducibleList.size());
+
   for (int ik : mpi->divideWorkIter(numPoints)) {
     int ikIrr = equiv(ik); // map to the irreducible in fullPoints
-    int ikIrr2 = -1;
-    for (int i = 0; i < numIrrPoints; i++) {
-      if (mapIrreducibleToReducibleList(i) == ikIrr) {
-        ikIrr2 = i;
-        break;
-      }
-    }
+    auto itr = std::lower_bound(mI2R.begin(), mI2R.end(), ikIrr);
+    int ikIrr2 = std::distance(mI2R.begin(), itr);
     if (ikIrr2 == -1) {
       Error("Failed building irreducible points mapRedToIrrList");
     }


### PR DESCRIPTION
Two parts of the band structure setup were causing slowdown for large meshes: 
* The filtering points part of activeBandStructure setup is now using OMP
* The selection of irreducible points in points.setIrreduciblePoints had a serious bottleneck caused by a linear search when setting up the map from irr points to reducible points. Switching this to binary search can seriously speed up some calculations on dense meshes.  