### PR TITLE
Bugfix: epaTransport app failed DFT calculations using smearing

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -584,7 +584,7 @@ void Context::setupFromInput(const std::string &fileName) {
         // note: numOccupiedStates refers to the number of states that are
         // occupied
         // for Wannier: the number of Wannier states that are full
-        // for Fourier: the number of occupied bands
+        // for Fourier: the number of occupied bands, minus the states trimmed
         // remember to NOT count the spin degeneracy
         double x = parseDouble(val);
         if (!hasSpinOrbit)

--- a/src/parser/qe_input_parser.cpp
+++ b/src/parser/qe_input_parser.cpp
@@ -651,8 +651,17 @@ QEParser::parseElHarmonicFourier(Context &context) {
   // note: nelec is written as double in the XML file!
   int numElectrons = int(bandStructureXML.child("nelec").text().as_double());
 
-  double homo =
-      bandStructureXML.child("highestOccupiedLevel").text().as_double();
+  // get fermi energy
+  double homo;
+  // it's an insulator
+  if (bandStructureXML.child("highestOccupiedLevel")) {
+    homo = bandStructureXML.child("highestOccupiedLevel").text().as_double();
+  } else if (bandStructureXML.child("fermi_energy")) { // it's a metal or run with smearing
+    homo = bandStructureXML.child("fermi_energy").text().as_double();
+  } else {
+    Error("Something is wrong, neither highestOccupiedLevel "
+        "nor fermi_energy tags appear in XML file.");
+  }
   homo *= 2.;// conversion from Hartree to Rydberg
   int numIrreduciblePoints = bandStructureXML.child("nks").text().as_int();
 


### PR DESCRIPTION
When the epaTransport app is run on calculations where smearing was used smearing, we were reading in only the xml tag for homo (which was zero, as it did not exist in the xml file) and not checking for the fermi_energy xml tag, which resulted in errors when trimming the number of bands in the calculation.