### PR TITLE
Electron viscosity corrected

### DIFF
--- a/src/apps/electron_wannier_transport_app.cpp
+++ b/src/apps/electron_wannier_transport_app.cpp
@@ -201,7 +201,7 @@ void ElectronWannierTransportApp::run(Context &context) {
     scatteringMatrix.relaxonsToJSON("exact_relaxation_times.json", eigenvalues);
 
     if (!context.getUseSymmetries()) {
-      Vector0 fermiEigenvector(statisticsSweep, bandStructure, specificHeat);
+      // Vector0 fermiEigenvector(statisticsSweep, bandStructure, specificHeat, true);
       elViscosity.calcFromRelaxons(eigenvalues, eigenvectors);
       elViscosity.print();
       elViscosity.outputToJSON("relaxons_electron_viscosity.json");

--- a/src/bte/drift.cpp
+++ b/src/bte/drift.cpp
@@ -59,13 +59,14 @@ BulkEDrift::BulkEDrift(StatisticsSweep &statisticsSweep_,
 }
 
 Vector0::Vector0(StatisticsSweep &statisticsSweep_,
-                 BaseBandStructure &bandStructure_, SpecificHeat &specificHeat)
+                 BaseBandStructure &bandStructure_, SpecificHeat &specificHeat,
+                 const bool& symmetrize)
     : VectorBTE(statisticsSweep_, bandStructure_, 1) {
 
   Particle particle = bandStructure.getParticle();
   std::vector<int> iss = bandStructure.parallelIrrStateIterator();
   int niss = iss.size();
-#pragma omp parallel for default(none) shared(bandStructure,statisticsSweep,particle,specificHeat, niss, iss)
+#pragma omp parallel for
   for(int iis = 0; iis < niss; iis++){
     int is = iss[iis];
     StateIndex isIdx(is);
@@ -75,7 +76,7 @@ Vector0::Vector0(StatisticsSweep &statisticsSweep_,
       auto calcStat = statisticsSweep.getCalcStatistics(iCalc);
       double temp = calcStat.temperature;
       double chemPot = calcStat.chemicalPotential;
-      double dnde = particle.getDnde(energy, temp, chemPot);
+      double dnde = particle.getDnde(energy, temp, chemPot, symmetrize);
       // note dn/de = n(n+1)/T  (for bosons)
       auto c = specificHeat.get(iCalc);
       double x = -dnde / temp / c;

--- a/src/bte/drift.h
+++ b/src/bte/drift.h
@@ -57,7 +57,7 @@ public:
    * @param specificHeat: object with the values of specific heat
    */
   Vector0(StatisticsSweep &statisticsSweep_, BaseBandStructure &bandStructure_,
-          SpecificHeat &specificHeat);
+          SpecificHeat &specificHeat, const bool& symmetrize = false);
 };
 
 #endif

--- a/src/observable/electron_viscosity.cpp
+++ b/src/observable/electron_viscosity.cpp
@@ -192,9 +192,10 @@ void ElectronViscosity::calcFromRelaxons(Eigen::VectorXd &eigenvalues,
     Eigen::Vector3d vel = bandStructure.getGroupVelocity(isIdx);
     double en = bandStructure.getEnergy(isIdx);
     double pop = particle.getPopPopPm1(en, temp, chemPot);
+    // true sets a sqrt term
     for (int k = 0; k < dimensionality; k++) {
       for (int l = 0; l < dimensionality; l++) {
-        fRelaxons(k, l, alpha) += vec(k) * vel(l) * pop / temp /
+        fRelaxons(k, l, alpha) += vec(k) * vel(l) * sqrt(pop) / temp /
                                   eigenvalues(alpha) * eigenvectors(is, alpha);
       }
     }
@@ -225,8 +226,10 @@ void ElectronViscosity::calcFromRelaxons(Eigen::VectorXd &eigenvalues,
       for (int j = 0; j < dimensionality; j++) {
         for (int k = 0; k < dimensionality; k++) {
           for (int l = 0; l < dimensionality; l++) {
+            // note: the sqrt(pop) is to rescale the population from the
+            // symmetrized exact BTE
             tensordxdxdxd(iCalc, i, j, k, l) +=
-                0.5 * pop * norm *
+                0.5 * pop * norm * sqrt(pop) *
                 (vec(i) * vel(j) * f(k, l, is) + vec(i) * vel(l) * f(k, j, is));
           }
         }


### PR DESCRIPTION
When the scattering matrix has been symmetrized, we forgot to correct the calculation of viscosity.