### PR TITLE
More general update of json library url

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,8 +15,7 @@ FetchContent_MakeAvailable(googletest)
 # which tracks the original, minus the large test data set.
 # This is recommended by the readme of nlohmann/json
 FetchContent_Declare(json
-#    GIT_REPOSITORY https://github.com/ArthurSonzogni/nlohmann_json_cmake_fetchcontent.git
-    URL https://github.com/nlohmann/json/releases/download/v3.11.1/json.tar.xz
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
     SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/json_src
     UPDATE_COMMAND ""
 )


### PR DESCRIPTION
The previous PR's update to the json url in CMakeLists worked on git actions and Harvard RC's cluster, however, did not work on all systems. This update is slightly more general and does appear to work globally. 