### PR TITLE
Make the cutoff for determining WS cell vectors slightly less strict

### DIFF
--- a/src/bte/scattering.cpp
+++ b/src/bte/scattering.cpp
@@ -117,7 +117,7 @@ void ScatteringMatrix::setup() {
     if (numCalculations > 1) {
       // note: one could write code around this
       // but the methods are very memory intensive for production runs
-      Error("High memory BTE methods can only work with one "
+      Error("High memory BTE methods (scatterngMatrixInMemory=true) can only work with one "
             "temperature and/or chemical potential in a single run");
     }
     int matSize;

--- a/src/bte/scattering.cpp
+++ b/src/bte/scattering.cpp
@@ -117,7 +117,7 @@ void ScatteringMatrix::setup() {
     if (numCalculations > 1) {
       // note: one could write code around this
       // but the methods are very memory intensive for production runs
-      Error("High memory BTE methods (scatterngMatrixInMemory=true) can only work with one "
+      Error("High memory BTE methods (scatteringMatrixInMemory=true) can only work with one "
             "temperature and/or chemical potential in a single run");
     }
     int matSize;

--- a/src/harmonic/phonon_h0.cpp
+++ b/src/harmonic/phonon_h0.cpp
@@ -505,18 +505,16 @@ Eigen::Tensor<double, 5> PhononH0::wsInit(const Eigen::MatrixXd &unitCell,
         }
       }
 
-      if (abs(total_weight - qCoarseGrid(0) * qCoarseGrid(1) * qCoarseGrid(2)) >
-          1.0e-8) {
-        std::cout << total_weight << " " << qCoarseGrid.prod() << "\n";
-        Error("wrong total_weight");
+      if (abs(total_weight - qCoarseGrid(0) * qCoarseGrid(1) * qCoarseGrid(2)) > 1.0e-8) {
+        Error("DeveloperError: wrong total_weight, weight: "
+                + std::to_string(total_weight) + " qMeshProd: " + std::to_string(qCoarseGrid.prod()) );
       }
     }
   }
   return wsCache;
 }
 
-double PhononH0::wsWeight(const Eigen::VectorXd &r,
-                          const Eigen::MatrixXd &rws) {
+double PhononH0::wsWeight(const Eigen::VectorXd &r, const Eigen::MatrixXd &rws) {
   // wsWeight() assigns this weight:
   // - if a point is inside the Wigner-Seitz cell:    weight=1
   // - if a point is outside the WS cell:             weight=0
@@ -537,10 +535,10 @@ double PhononH0::wsWeight(const Eigen::VectorXd &r,
   for (int ir = 0; ir < rws.cols(); ir++) {
     double rrt = r.dot(rws.col(ir));
     double ck = rrt - rws.col(ir).squaredNorm() / 2.;
-    if (ck > 1.0e-6) {
+    if (ck > 1.0e-5) {
       return 0.;
     }
-    if (abs(ck) < 1.0e-6) {
+    if (abs(ck) <= 1.0e-5) {
       numREq += 1;
     }
   }

--- a/src/harmonic/phonon_h0.h
+++ b/src/harmonic/phonon_h0.h
@@ -172,6 +172,8 @@ protected:
   Eigen::Matrix3d dielectricMatrix;
   Eigen::Tensor<double, 3> bornCharges;
   Eigen::Vector3i qCoarseGrid;
+  Eigen::Matrix3d directUnitCell;
+  int dimensionality;
 
   int numBravaisVectors = 0;
   Eigen::MatrixXd bravaisVectors;

--- a/src/harmonic/phonon_h0.h
+++ b/src/harmonic/phonon_h0.h
@@ -174,6 +174,9 @@ protected:
   Eigen::Vector3i qCoarseGrid;
   Eigen::Matrix3d directUnitCell;
   int dimensionality;
+  // TODO -- when long range correction for dim=2 has been really well checked,
+  // uncomment this to activate it
+  bool longRange2d = false;
 
   int numBravaisVectors = 0;
   Eigen::MatrixXd bravaisVectors;


### PR DESCRIPTION
The cutoff for determining which vectors are in the WS cell (in the wsWeight function of the phononH0 class) was sometimes too strict, and gave zero weight to vectors which were actually in the WS cell. This loosens that cutoff slightly to avoid error messages to users and produce the correct behavior. 

There is also some draft material for changing the behavior of the LOTO correction in the case of dimensionality=2 added in phononH0, based on what is done in rigid.f90 of QE. However, for now this is turned off with a boolean variable (longRange2d) at the start of phononH0. I don't have time to test this super thoroughly right at this moment, but I want to make sure the progress is saved. 