### PR TITLE
Deprecated HighFive MPI file driver

### DIFF
--- a/doc/sphinx/source/inputFiles.rst
+++ b/doc/sphinx/source/inputFiles.rst
@@ -99,7 +99,7 @@ Phonon BTE Solver
 
 * :ref:`phonopyDispFileName`
 
-* :ref: `phonopyBORNFileName`
+* :ref:`phonopyBORNFileName`
 
 * :ref:`sumRuleFC2`
 
@@ -1393,13 +1393,13 @@ deltaPath
 outputEigendisplacements
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* **Description:** Optional variable which outputs the phonon eigendisplacements to the ``phonon_bands.json`` file when using the ``phononBands`` app. See the :ref:`eigendisplacements` tutorial for more information on use. 
+* **Description:** Optional variable which outputs the phonon eigendisplacements to the ``phonon_bands.json`` file when using the ``phononBands`` app. See the :ref:`eigendisplacements` tutorial for more information on use.
 
 * **Default:** false
 
 * **Format:** *bool*
 
-* **Required:** no 
+* **Required:** no
 
 .. _elPhInterpolation:
 

--- a/src/apps/qe_to_phoebe_utils.cpp
+++ b/src/apps/qe_to_phoebe_utils.cpp
@@ -482,9 +482,9 @@ void writeElPhCouplingHDF5v1(
 
     {
       // open the hdf5 file
-      HighFive::File file(
-          outFileName, HighFive::File::Overwrite,
-          HighFive::MPIOFileDriver(MPI_COMM_WORLD, MPI_INFO_NULL));
+      HighFive::FileAccessProps fapl;
+      fapl.add(HighFive::MPIOFileAccess{MPI_COMM_WORLD, MPI_INFO_NULL});
+      HighFive::File file(outFileName, HighFive::File::Overwrite, fapl);
 
       // flatten the tensor (tensor is not supported) and create the data set
       Eigen::VectorXcd gwan = Eigen::Map<Eigen::VectorXcd, Eigen::Unaligned>(

--- a/src/apps/qe_to_phoebe_utils.cpp
+++ b/src/apps/qe_to_phoebe_utils.cpp
@@ -482,8 +482,8 @@ void writeElPhCouplingHDF5v1(
 
     {
       // open the hdf5 file
-      HighFive::FileAccessProps fapl;
-      fapl.add(HighFive::MPIOFileAccess{MPI_COMM_WORLD, MPI_INFO_NULL});
+      HighFive::FileAccessProps fapl;// = HighFive::FileAccessProps{};
+      fapl.add(HighFive::MPIOFileAccess<MPI_Comm, MPI_Info>(MPI_COMM_WORLD, MPI_INFO_NULL));
       HighFive::File file(outFileName, HighFive::File::Overwrite, fapl);
 
       // flatten the tensor (tensor is not supported) and create the data set

--- a/src/interaction/interaction_elph_parsing.cpp
+++ b/src/interaction/interaction_elph_parsing.cpp
@@ -352,8 +352,9 @@ InteractionElPhWan parseHDF5V1(Context &context, Crystal &crystal,
     }
 
     // Reopen the HDF5 ElPh file for parallel read of eph matrix elements
-    HighFive::File file(fileName, HighFive::File::ReadOnly,
-        HighFive::MPIOFileDriver(mpi->getComm(comm), MPI_INFO_NULL));
+    HighFive::FileAccessProps fapl;
+    fapl.add(HighFive::MPIOFileAccess{mpi->getComm(comm), MPI_INFO_NULL});
+    HighFive::File file(fileName, HighFive::File::ReadOnly, fapl);
 
     // Set up dataset for gWannier
     HighFive::DataSet dgWannier = file.getDataSet("/gWannier");

--- a/src/interaction/interaction_elph_parsing.cpp
+++ b/src/interaction/interaction_elph_parsing.cpp
@@ -352,8 +352,8 @@ InteractionElPhWan parseHDF5V1(Context &context, Crystal &crystal,
     }
 
     // Reopen the HDF5 ElPh file for parallel read of eph matrix elements
-    HighFive::FileAccessProps fapl;
-    fapl.add(HighFive::MPIOFileAccess{mpi->getComm(comm), MPI_INFO_NULL});
+    HighFive::FileAccessProps fapl = HighFive::FileAccessProps{};
+    fapl.add(HighFive::MPIOFileAccess<MPI_Comm, MPI_Info>(mpi->getComm(comm), MPI_INFO_NULL));
     HighFive::File file(fileName, HighFive::File::ReadOnly, fapl);
 
     // Set up dataset for gWannier


### PR DESCRIPTION
HighFive recently deprecated their MPIOFileDriver object, and moved it's functions into the FileDriver class instead. This PR fixes an issue where on some systems, the deprecation warning instead causes an error. 