### PR TITLE
Minor update to band structure output and plotting

### DIFF
--- a/doc/sphinx/source/tutorials/bands.rst
+++ b/doc/sphinx/source/tutorials/bands.rst
@@ -1,18 +1,18 @@
 .. _bands:
 
-Basic Band Structure and DoS 
+Basic Band Structure and DoS
 ==============================
 
 Synopsis
 --------
 
-In addition to transport and lifetime calculations, Phoebe can also perform basic band structure and density of states calculations. These can be useful when debugging a calculation or checking the quality of a Wannier or Fourier interpolation. The quality of interpolation is often dependent on the number of k or q points used in DFT, so sometimes it can be helpful to run this calculation to ensure that your DFT calculation used a dense enough mesh. 
+In addition to transport and lifetime calculations, Phoebe can also perform basic band structure and density of states calculations. These can be useful when debugging a calculation or checking the quality of a Wannier or Fourier interpolation. The quality of interpolation is often dependent on the number of k or q points used in DFT, so sometimes it can be helpful to run this calculation to ensure that your DFT calculation used a dense enough mesh.
 
 
 Step 1: Generate input files
 --------------------------------------
 
-For this short tutorial, we're going to use Quantum Espresso output files for electrons, and phono3py output for phonons, as generated from one of the other tutorials. 
+For this short tutorial, we're going to use Quantum Espresso output files for electrons, and phono3py output for phonons, as generated from one of the other tutorials.
 
 Before performing this calculation, you should either run steps 1-3 of the :ref:`elWanTransport` or steps 1-3 of the :ref:`phononTransport`. The input files necessary for the electron and phonon bands calculations are:
 
@@ -42,7 +42,7 @@ Before performing this calculation, you should either run steps 1-3 of the :ref:
 * phono3py_disp.yaml (or phonopy_disp.yaml harmonic only)
 * disp_fc3.yaml (or disp.yaml if harmonic only)
 
-After running at least the necessary steps of these prior calculations and copying this output into your current directory (or at least, noting the path to the files so that you can specify it in the below input files), we can proceed to the next step. 
+After running at least the necessary steps of these prior calculations and copying this output into your current directory (or at least, noting the path to the files so that you can specify it in the below input files), we can proceed to the next step.
 
 
 Step 2: Using Phoebe to calculate band structure
@@ -80,6 +80,7 @@ Once we have the necessary input files, we run Phoebe using one of the input fil
 ::
 
   appName = "electronFourierBands"
+  # note that this XML file should be from an NSCF run
   electronH0Name = "silicon.xml"
   deltaPath = 0.1
   electronFourierCutoff = 4.
@@ -88,7 +89,7 @@ Once we have the necessary input files, we run Phoebe using one of the input fil
   begin point path
   L 0.50000  0.50000 0.5000 G 0.00000  0.00000 0.0000
   G 0.00000  0.00000 0.0000 X 0.50000  0.00000 0.5000
-  X 0.50000 -0.50000 0.0000 K 0.37500 -0.37500 0.0000 
+  X 0.50000 -0.50000 0.0000 K 0.37500 -0.37500 0.0000
   K 0.37500 -0.37500 0.0000 G 0.00000  0.00000 0.0000
   end point path
 
@@ -99,7 +100,7 @@ Once we have the necessary input files, we run Phoebe using one of the input fil
 
 ::
 
-  phFC2FileName = "silicon.fc" 
+  phFC2FileName = "silicon.fc"
   sumRuleFC2 = "simple"
   appName = "phononBands"
   useSymmetries = true
@@ -107,7 +108,7 @@ Once we have the necessary input files, we run Phoebe using one of the input fil
   begin point path
   L 0.50000  0.50000 0.5000 G 0.00000  0.00000 0.0000
   G 0.00000  0.00000 0.0000 X 0.50000  0.00000 0.5000
-  X 0.50000 -0.50000 0.0000 K 0.37500 -0.37500 0.0000 
+  X 0.50000 -0.50000 0.0000 K 0.37500 -0.37500 0.0000
   K 0.37500 -0.37500 0.0000 G 0.00000  0.00000 0.0000
   end point path
 
@@ -126,15 +127,15 @@ As we can see, these input files are relatively similar. We briefly describe the
 
 * :ref:`sumRuleFC2`: tells Phoebe to use either the simple or crystal acoustic sum rule for the harmonic phonons.
 
-* :ref:`electronH0Name`: used for the electronic case, this points to the ``*_tb.dat`` file from Wannier90.
+* :ref:`electronH0Name`: used for the electronic case, this points to the ``*_tb.dat`` file from Wannier90 or for Fourier bands, an NSCF calculation's ``*.xml`` output.
 
 * :ref:`deltaPath`: this parameter specifies the spacing of points along the band path. Smaller values will give a band path along a finer wavevector path.
 
-* :ref:`electronFourierCutoff`: this parameter specifies the cutoff size of the supercell used in the Fourier interpolation process. The calculation expense scales as :math:`N^3` for this parameter, and you will only see improvement up to a certain point. 
+* :ref:`electronFourierCutoff`: this parameter specifies the cutoff size of the supercell used in the Fourier interpolation process. The calculation expense scales as :math:`N^3` for this parameter, and you will only see improvement up to a certain point.
 
-* :ref:`useSymmetries`: this turns on the use of symmetries in Phoebe, which can speed up the calculation. 
+* :ref:`useSymmetries`: this turns on the use of symmetries in Phoebe, which can speed up the calculation.
 
-* The ``begin crystal`` and ``end crystal`` block is used to provide the crystal structure used in the Wannier90 calculation in crystal coordinates, as this information is not stored in the tb.dat file. 
+* The ``begin crystal`` and ``end crystal`` block is used to provide the crystal structure used in the Wannier90 calculation in crystal coordinates, as this information is not stored in the tb.dat file.
 
 * Finally, the ``begin point path`` and ``end point path`` specify the band path along which we will calculate the lifetimes.
 
@@ -203,15 +204,15 @@ We can also use these inputs to run a DoS calculation, as shown in example files
   useSymmetries = true
 
 
-As we can see, these input files are all pretty much the same. We briefly describe the relevant input parameters below (without repeating those already defined in the bands step above): 
+As we can see, these input files are all pretty much the same. We briefly describe the relevant input parameters below (without repeating those already defined in the bands step above):
 
 * :ref:`appName`: we set this to ``electronWannierDos``, ``electronFourierDos``, or ``phononDos`` to tell Phoebe to run the app to generate the band structure of choice.
 
-* :ref:`qMesh` or :ref:`kMesh`: for the phonon and electron cases, respectively, these variables specify the fine mesh of points used to calculate the DoS. 
+* :ref:`qMesh` or :ref:`kMesh`: for the phonon and electron cases, respectively, these variables specify the fine mesh of points used to calculate the DoS.
 
-* :ref:`dosMinEnergy` and :ref:`dosMaxEnergy`: these parameters define the minimum and maximum energies for which the DoS is calculated. 
+* :ref:`dosMinEnergy` and :ref:`dosMaxEnergy`: these parameters define the minimum and maximum energies for which the DoS is calculated.
 
-* :ref:`dosDeltaEnergy`: specifies the increment size in energy for which the DoS will be calculated. 
+* :ref:`dosDeltaEnergy`: specifies the increment size in energy for which the DoS will be calculated.
 
 Again using the files set up in step 1, we can run the DoS calculation using the input file of our choice::
 
@@ -225,13 +226,13 @@ These apps are well parallelized over OMP threads or MPI processes, so set the a
 Plotting phonon eigendisplacements
 -----------------------------------------------------
 
-In the phonon bands case, Phoebe offers one additional option to plot the phonon eigendisplacements. This is sometimes useful, for example, the eigendisplacements can help diagnose the physical origin of an unstable phonon mode. 
+In the phonon bands case, Phoebe offers one additional option to plot the phonon eigendisplacements. This is sometimes useful, for example, the eigendisplacements can help diagnose the physical origin of an unstable phonon mode.
 
 If one sets the input file variable :ref:`outputEigendisplacements` = true, the ``phononBands`` app will write the phonon eigendisplacements to the output ``phonon_bands.json`` file. Then, the eigendisplacements can be easily plotted for visualization in VESTA using the script shipped with Phoebe under ``phoebe/scripts/plotScripts/plotEigendisplacements.py``, using the syntax::
 
   python plotEigendisplacements.py qxCrys qyCrys qzCrys nMode outputName.xsf
 
-where you need to supply the phonon wavevector in crystal coordinates, the branch index of the eigendisplacement (indexed from zero), and the name of the XSF file you want to output + the extension ``.xsf``, which will enable you to open it in VESTA. The output will look something like this: 
+where you need to supply the phonon wavevector in crystal coordinates, the branch index of the eigendisplacement (indexed from zero), and the name of the XSF file you want to output + the extension ``.xsf``, which will enable you to open it in VESTA. The output will look something like this:
 
 .. image:: ../images/si.vec.png
   :width: 35%
@@ -281,11 +282,11 @@ This script will generate the following images, as below for the electron bands 
 Convergence Checklist
 ----------------------
 
-As always, this is a demo calculation. However, it's a very simple one, and there are only a few parameters which affect the end calculation. 
+As always, this is a demo calculation. However, it's a very simple one, and there are only a few parameters which affect the end calculation.
 
-* The convergence of your electronic and phonon DFT calculations is of course, critical to this calculation (energy cutoff, k/q mesh, etc). 
+* The convergence of your electronic and phonon DFT calculations is of course, critical to this calculation (energy cutoff, k/q mesh, etc).
 
-* **In particular, the electron Fourier interpolation can need many k-points to converge effectively.** This is not a limitation of Phoebe -- simply, Fourier interpolation requires many points to reach a high quality replication of the electronic structure. 
+* **In particular, the electron Fourier interpolation can need many k-points to converge effectively.** This is not a limitation of Phoebe -- simply, Fourier interpolation requires many points to reach a high quality replication of the electronic structure.
 
 * You also should converge the DoS with respect to the kMesh/qMesh sampling of the Phoebe calculation.
 

--- a/scripts/plotScripts/bands.py
+++ b/scripts/plotScripts/bands.py
@@ -31,23 +31,6 @@ if __name__ == "__main__":
 
     pathTicks = data['highSymIndices']
 
-    # if the path has a fictitious discontinuity
-    # e.g. in going from X=(0.50000  0.00000 0.5000) to X=(0.50000 -0.50000 0.0000)
-    # (which are the same in a FCC lattice), the JSON plots two different points
-    # Here we recombine them into one. Equality is checked by the label
-    enIndexToDelete = []
-    tkIndexToDelete = []
-    for i in range(len(pathLabels)-1):
-        if ( pathLabels[i] == pathLabels[i+1] and pathTicks[i] != pathTicks[i+1]):
-            tkIndexToDelete.append(i+1)
-            enIndexToDelete.append(pathTicks[i+1])
-    for en,tk in zip(enIndexToDelete[::-1],tkIndexToDelete[::-1]):
-        points = np.delete(points, -1)
-        pathLabels = np.delete(pathLabels, tk)
-        pathTicks = np.delete(pathTicks, tk)
-        pathTicks[tk:] -= 1
-        energies = np.delete(energies, en, 0)
-
     # plot some vertical lines at high sym points
     plt.figure(figsize=(5.5,5))
     for i in pathTicks:

--- a/scripts/plotScripts/tau_path.py
+++ b/scripts/plotScripts/tau_path.py
@@ -161,25 +161,6 @@ if __name__ == "__main__":
     points = np.array(data2['wavevectorIndices'])
     energies = np.array(data2['energies'])
 
-    # if the path has a fictitious discontinuity
-    # e.g. in going from X=(0.50000  0.00000 0.5000) to X=(0.50000 -0.50000 0.0000)
-    # (which are the same in a FCC lattice), the JSON plots two different points
-    # Here we recombine them into one. Equality is checked by the label
-    enIndexToDelete = []
-    tkIndexToDelete = []
-    for i in range(len(pathLabels)-1):
-        if ( pathLabels[i] == pathLabels[i+1] and pathTicks[i] != pathTicks[i+1]):
-            tkIndexToDelete.append(i+1)
-            enIndexToDelete.append(pathTicks[i+1])
-    for en,tk in zip(enIndexToDelete[::-1],tkIndexToDelete[::-1]):
-        points = np.delete(points, -1)
-        pathLabels = np.delete(pathLabels, tk)
-        pathTicks = np.delete(pathTicks, tk)
-        pathTicks[tk:] -= 1
-        energies = np.delete(energies, en, 0)
-        tau = np.delete(tau, en, 0)
-        lwidths = np.delete(lwidths, en, 0)
-
     plotFileName = os.path.splitext(jfileName)[0] + ".tau.pdf"
     punchPlotTau(plotFileName, tau, points, pathTicks, pathLabels)
 

--- a/scripts/plotScripts/tau_path_color.py
+++ b/scripts/plotScripts/tau_path_color.py
@@ -43,25 +43,6 @@ numBands = dataPath['numBands']
 linewidths = linewidths[calcIndex]
 tau = np.array(tau[calcIndex])
 
-# if the path has a fictitious discontinuity
-# e.g. in going from X=(0.50000  0.00000 0.5000) to X=(0.50000 -0.50000 0.0000)
-# (which are the same in a FCC lattice), the JSON plots two different points
-# Here we recombine them into one. Equality is checked by the label
-enIndexToDelete = []
-tkIndexToDelete = []
-for i in range(len(pathLabels)-1):
-    if ( pathLabels[i] == pathLabels[i+1] and pathTicks[i] != pathTicks[i+1]):
-        tkIndexToDelete.append(i+1)
-        enIndexToDelete.append(pathTicks[i+1])
-for en,tk in zip(enIndexToDelete[::-1],tkIndexToDelete[::-1]):
-    points = np.delete(points, -1)
-    pathLabels = np.delete(pathLabels, tk)
-    pathTicks = np.delete(pathTicks, tk)
-    pathTicks[tk:] -= 1
-    energies = np.delete(energies, en, 0)
-    tau = np.delete(tau,en,0)
-    linewidths = np.delete(linewidths,en,0)
-
 def custom_div_cmap(numcolors=11, name='custom_div_cmap',
                     mincol='blue', midcol='white', maxcol='red'):
     from matplotlib.colors import LinearSegmentedColormap

--- a/src/apps/bands_app.cpp
+++ b/src/apps/bands_app.cpp
@@ -151,20 +151,25 @@ void outputBandsToJSON(FullBandStructure &fullBandStructure, Context &context,
     // store the path coordinates
     auto coord = pathPoints.getPointCoordinates(ik);
     pathCoordinates.push_back({coord[0], coord[1], coord[2]});
-
+    auto pathLabels = context.getPathLabels();
     // check if this point is one of the high sym points,
     // and if it is, save the index
     if (coord[0] == extremaCoordinates[extremaCount][0] &&
         coord[1] == extremaCoordinates[extremaCount][1] &&
         coord[2] == extremaCoordinates[extremaCount][2]) {
+
       pathLabelIndices.push_back(ik);
       // if the next extrema is the same as this one, add the index
       //  twice and increment extrema count twice.
       // we have to do this because the point won't occur a second time
       // in the path list.
+      // Alternatively, if this pathLabel and the next pathLabel are the same,
+      // even if the extremaCoordinates are not the same, they are considered the same point.
+      // This can happen when two band path points are sym equiv, such as the X points
+      // 0.5 0 0.5 and 0.5 -0.5 0 in the FCC lattice.
       if (extremaCount + 1 < extremaCoordinates.size()) { // check bounds
-        if (extremaCoordinates[extremaCount] ==
-            extremaCoordinates[extremaCount + 1]) {
+        if (extremaCoordinates[extremaCount] == extremaCoordinates[extremaCount + 1]
+                || pathLabels[extremaCount] == pathLabels[extremaCount + 1]) {
           pathLabelIndices.push_back(ik);
           extremaCount += 2;
         } else {

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -382,6 +382,7 @@ std::vector<std::string> Context::split(const std::string &s, char delimiter) {
 /** Checks if the line of the input file contains a key=value statement.
  */
 bool lineHasParameter(const std::string &line) {
+  // parse the line
   if (std::find(line.begin(), line.end(), '=') != line.end()) {
     return true;
   } else {
@@ -429,12 +430,12 @@ void Context::setupFromInput(const std::string &fileName) {
   }
 
   int lineCounter = 0;
-  for (const std::string &line : lines) {
-    if (line.empty()) { // nothing to do
-      continue;
+  for (std::string &line : lines) {
 
-      // skip the line if it's commented out with #
-    } else if (line[line.find_first_not_of(" ")] == '#') {
+    // remove any part of the line that is beind a # comment first
+    line = line.substr(0, line.find_first_of("#"));
+
+    if (line.empty()) { // nothing to do
       continue;
 
       // line with pair (key,value)

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -433,6 +433,10 @@ void Context::setupFromInput(const std::string &fileName) {
     if (line.empty()) { // nothing to do
       continue;
 
+      // skip the line if it's commented out with #
+    } else if (line[line.find_first_not_of(" ")] == '#') {
+      continue;
+
       // line with pair (key,value)
     } else if (lineHasParameter(line)) {
       auto tup = parseParameterNameValue(line);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -306,6 +306,7 @@ parsePathExtrema(std::vector<std::string> &lines) {
 
   int i = 0;
   for (const std::string &line : lines) {
+
     // split line by spaces
     std::stringstream ss(line);
     std::istream_iterator<std::string> begin(ss);
@@ -1012,7 +1013,8 @@ void Context::printInputSummary(const std::string &fileName) {
     for (int i = 0; i < dim[0]; i++) {
       std::cout << pathLabels[count] << " " << pathExtrema(i, 0, 0) << " "
                 << pathExtrema(i, 0, 1) << " " << pathExtrema(i, 0, 2) << "  ";
-      std::cout << pathLabels[count + 1] << " " << pathExtrema(i, 1, 0) << " "
+      count++;
+      std::cout << pathLabels[count] << " " << pathExtrema(i, 1, 0) << " "
                 << pathExtrema(i, 1, 1) << " " << pathExtrema(i, 1, 2)
                 << std::endl;
       count++;

--- a/src/parser/qe_input_parser.cpp
+++ b/src/parser/qe_input_parser.cpp
@@ -669,7 +669,13 @@ QEParser::parseElHarmonicFourier(Context &context) {
   // this may or may not be present! if so, I get mesh and offset
   pugi::xml_node mp = startingKPoints.child("monkhorst_pack");
   if (mp) {
-    Error("Grid found in QE:XML, should have used full kPoints grid");
+    if(mpi->mpiHead()) {
+        Error("Found Monkhorst-Pack mesh in XML file.\n"
+        "This likely means you're reading in an SCF XML file, which\n"
+        "doesn't make sense for Phoebe -- likely you forgot to perform NSCF on\n"
+        "the full k-mesh first.");
+    }
+    // Error("Grid found in QE:XML, should have used full kPoints grid");
   }
 
   // Initialize the crystal class


### PR DESCRIPTION
### This minor PR fixes/adds: 
* a bug in the printing of the band path to Phoebe's output file
* proper ignoring of comments coming after a # character in input files
* simplification of bands_app output. Now, when two consecutive high symmetry points with the same name are given in the input file, even if they have different coordinates, the high sym band path indices output for those two points will be the same. This means we can also accordingly remove a slightly convoluted fix for this that was sometimes causing issues in our bands plot script. 