### PR TITLE
Minor bug fixes related to git discussions #172 and #173

### DIFF
--- a/doc/sphinx/source/tutorials/mlPhononTransport.rst
+++ b/doc/sphinx/source/tutorials/mlPhononTransport.rst
@@ -6,17 +6,17 @@ Accelerated Lattice Thermal Conductivity Calculations using Machine Learning For
 Synopsis
 --------
 
-In this tutorial, we will use Phoebe to compute the lattice thermal conductivity of silicon carbide (SiC) with a machine learning force field from `FLARE <https://github.com/mir-group/flare>`_. 
+In this tutorial, we will use Phoebe to compute the lattice thermal conductivity of silicon carbide (SiC) with a machine learning force field from `FLARE <https://github.com/mir-group/flare>`_.
 
 This tutorial is based on the thermal conductivity calculation of SiC in `this paper <https://arxiv.org/abs/2203.03824>`_.
 
 .. note::
   Support of phono3py is only available if Phoebe is built using `hdf5`. It's needed for this tutorial.
 
-We will use 
+We will use
 
 * Python (+ LAMMPS) to train a machine learning force field
-* Phono3py to generate super cells with different displacements 
+* Phono3py to generate super cells with different displacements
 * LAMMPS to compute forces for those super cells
 * Phono3py to compute the force constants
 * Phoebe to compute the lattice thermal conductivity.
@@ -26,7 +26,7 @@ Step 0: Train a Machine Learning Force Field
 
 Machine learning force field (MLFF) builds a model to predict energy/forces/stress from atomic coordinates, using machine learning algorithms. The model is usually trained from DFT data, and can reach first-principles accuracy while keep the linear scaling with system size in the computational cost. Therefore, the MLFF usually reaches 3-6 orders of magnitude speedup compared to DFT in production.
 
-After a MLFF is trained, we can use it for large-scale molecular dynamics, and phonon transport calculations, where the latter is the subject of this tutorial. 
+After a MLFF is trained, we can use it for large-scale molecular dynamics, and phonon transport calculations, where the latter is the subject of this tutorial.
 
 Before any phonon transport calculations, we need to train a MLFF from the first-principles data. The MLFF model we use is `FLARE <https://github.com/mir-group/flare>`_, a Gaussian process regression model with many-body descriptors. The training can be efficiently done through Bayesian active learning, and we direct the users to the `FLARE tutorial <https://colab.research.google.com/drive/1qgGlfu1BlXQgSrnolS4c4AYeZ-2TaX5Y?usp=sharing>`_ to generate a force field before continuing.
 
@@ -41,13 +41,13 @@ Detailed explanation can be found in the tutorial linked above.
 Step 1: Phono3py Installation
 -----------------------------
 
-See :ref:`phono3pyInstallation`. 
+See :ref:`phono3pyInstallation`.
 
 
 Step 2: Relax the Atomic Structure
 ----------------------------------
 
-As introduced in Step 0, suppose we have trained a good MLFF of SiC, compiled LAMMPS executable (`lmp_mpi`) with FLARE-LAMMPS code, and obtained a coefficient file (`lmp.flare`) for FLARE SiC force field. 
+As introduced in Step 0, suppose we have trained a good MLFF of SiC, compiled LAMMPS executable (`lmp_mpi`) with FLARE-LAMMPS code, and obtained a coefficient file (`lmp.flare`) for FLARE SiC force field.
 Before computing force constants, we need to relax the unit cell with our MLFF. The relaxation is done by LAMMPS, with the Python interface provided by `ASE <https://wiki.fysik.dtu.dk/ase/ase/calculators/lammps.html>`_.
 
 We first set up the ASE calculator of LAMMPS, where the LAMMPS input/output files will be saved in the `tmp` folder, and each LAMMPS calculation will run a relaxation of the cell and atomic positions. We run the relaxation `repeat=5` times to make sure the structure is relaxed sufficiently.
@@ -59,8 +59,8 @@ We first set up the ASE calculator of LAMMPS, where the LAMMPS input/output file
     import os, glob, shutil, sys
     from copy import deepcopy
     from ase.calculators.lammpsrun import LAMMPS
-    
-    
+
+
     def relax(struc, pot_file, lmp_command, specorder, repeat=5):
         """
         Relax cell and positions with LAMMPS
@@ -80,33 +80,33 @@ We first set up the ASE calculator of LAMMPS, where the LAMMPS input/output file
             minimize="1.0e-4 1.0e-6 100 1000",          # lammps command of relaxing atomic positions
             fix=["1 all box/relax iso 0.0 vmax 0.001"], # lammps command of relaxing cell
         )
-    
+
         # run relaxation multiple times
         for i in range(repeat):
             atoms = deepcopy(struc)
             atoms.calc = deepcopy(calc)
             atoms.get_forces()
-        
+
             trj_files = glob.glob("tmp/trj*")
             assert len(trj_files) == 1
             struc = read(trj_files[0], specorder=specorder, format="lammps-dump-binary")
             os.remove(trj_files[0])
-    
+
         return struc
 
 We can start with a DFT relaxed unit cell structure or one downloaded from a site like the Materials Project. We then relax the structure with the ASE LAMMPS calculator and save the relaxed structure to file (`POSCAR-unitcell`).
 
 .. code:: python
-    
+
     # Read an atomic structure of unit cell from file (can be a DFT structure or downloaded from online)
     dft_struc = read(f"POSCAR", format="vasp")
 
     # Relax the structure using LAMMPS and FLARE force field
     struc = relax(
-        dft_struc, 
-        pot_file="lmp.flare", 
-        lmp_command="./lmp_mpi", 
-        specorder=["Si", "C"], 
+        dft_struc,
+        pot_file="lmp.flare",
+        lmp_command="./lmp_mpi",
+        specorder=["Si", "C"],
         repeat=5,
     )
 
@@ -139,7 +139,7 @@ After obtaining a relaxed unit cell, we use the Python interface of phonopy and 
             pair_style="flare",
             pair_coeff=[f"* * {pot_file}"],
         )
-        return calc    
+        return calc
 
 Then we use `phono3py Python API <https://phonopy.github.io/phono3py/phono3py-api.html>`_ to make supercells and generate displacements.
 Here we use different supercell sizes for 2nd order force constants (6x6x2) and 3rd order force constants (3x3x3). And for 3rd order force constants, we use a cutoff pair distance 2.5A.
@@ -154,9 +154,9 @@ Here we use different supercell sizes for 2nd order force constants (6x6x2) and 
     # generate displacements
     unitcell, _ = read_crystal_structure("POSCAR-unitcell", interface_mode='vasp')
     ph3 = Phono3py(
-        unitcell, 
-        supercell_matrix=[3, 3, 3], 
-        primitive_matrix='auto', 
+        unitcell,
+        supercell_matrix=[3, 3, 3],
+        primitive_matrix='auto',
         phonon_supercell_matrix=[6, 6, 2],
     )
     ph3.generate_displacements(cutoff_pair_distance=2.5)
@@ -167,7 +167,7 @@ Next, we use ASE LAMMPS calculator to compute forces of the displaced supercells
 
 .. code:: python
 
-    pot_file = "lmp.flare" 
+    pot_file = "lmp.flare"
     specorder = ["Si", "C"]
     lmp_command = "./lmp_mpi"
 
@@ -190,8 +190,8 @@ Then phono3py computes the 2nd order force constants and write to a file ``fc2.h
     print("Computing FC2")
     ph3.produce_fc2()
     write_fc2_to_hdf5(
-        ph3.fc2, 
-        p2s_map=ph3.primitive.p2s_map, 
+        ph3.fc2,
+        p2s_map=ph3.phonon_primitive.p2s_map,
         physical_unit="eV/angstrom^2",
     )
 
@@ -218,8 +218,8 @@ In the same way, the 3rd order force constants can be generated and written into
     print("Computing FC3")
     ph3.produce_fc3()
     write_fc3_to_hdf5(
-        ph3.fc3, 
-        p2s_map=ph3.primitive.p2s_map, 
+        ph3.fc3,
+        p2s_map=ph3.primitive.p2s_map,
     )
 
 The files ``fc2.hdf5`` and ``fc3.hdf5`` will be used by Phoebe.
@@ -231,4 +231,4 @@ Step 4: Calculate Lattice Thermal Conductivity
 ------------------------------------------------
 
 If this dispersion looks good, we are now ready to move on to phonon transport calculations using Phoebe.
-See :ref:`thermalConductivityCalculation` of the :ref:`phononTransport` for instructions on how to use these files to generate lattice thermal conductivity. 
+See :ref:`thermalConductivityCalculation` of the :ref:`phononTransport` for instructions on how to use these files to generate lattice thermal conductivity.

--- a/example/Silicon-ph/phononBands.in
+++ b/example/Silicon-ph/phononBands.in
@@ -2,6 +2,8 @@ phFC2FileName = "qe-phonons/silicon.fc",
 sumRuleFC2 = "simple"
 appName = "phononBands"
 
+# fill in the appropriate band path for your
+# structure here
 begin point path
 L 0.50000  0.50000 0.5000 G 0.00000  0.00000 0.0000
 G 0.00000  0.00000 0.0000 X 0.50000  0.00000 0.5000

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -436,6 +436,7 @@ void Context::setupFromInput(const std::string &fileName) {
     line = line.substr(0, line.find_first_of("#"));
 
     if (line.empty()) { // nothing to do
+      lineCounter ++;
       continue;
 
       // line with pair (key,value)


### PR DESCRIPTION
## Summary 

1) Comments were causing "block" input variables to be read in incorrectly. This included "points path" blocks used in band structure calculations, as discussed in #173 and initially introduced in PR #171 about a week ago. 
    * FIX: Reading in now occurs correctly, and a comment has been added to one of the test input files so that this is checked in the future. 

2) As brought up in git discussion #172 -- the MLFF thermal conductivity tutorial had an error for the case where different FC2 and FC3 supercells were used. The fc2.hdf5 files were written with an incorrect p2s_map, which lead to the force constants being read in scrambled. 
    * FIX: For anyone using this tutorial's python script, the fix is to simply change:  
    `p2s_map=ph3.primitive.p2s_map,`
    to 
    `p2s_map=ph3.phonon_primitive.p2s_map,`

    in the block of code: 
    ```
    print("Computing FC2")
    ph3.produce_fc2()
    write_fc2_to_hdf5(
        ph3.fc2,
        p2s_map=ph3.phonon_primitive.p2s_map,
        physical_unit="eV/angstrom^2",
    )
    ``` 
NOTE: Thanks to users @wugaxp and @matukumilli for helping us identify these issues!

