### PR TITLE
Major improvements to relaxon solver

### DIFF
--- a/doc/sphinx/source/inputFiles.rst
+++ b/doc/sphinx/source/inputFiles.rst
@@ -147,7 +147,9 @@ Phonon BTE Solver
 
 * :ref:`useSymmetries`
 
+* :ref:`numRelaxonsEigenvalues`
 
+* :ref:`checkNegativeRelaxons`
 
 .. raw:: html
 
@@ -156,15 +158,19 @@ Phonon BTE Solver
 ::
 
   appName = "phononTransport"
+
   phFC2FileName = "./ForceConstants2nd"
-  sumRuleFC2 = "crystal"
   phFC3FileName = "./ForceConstants3rd"
+  sumRuleFC2 = "crystal"
   qMesh = [10,10,10]
   temperatures = [300.]
   smearingMethod = "adaptiveGaussian"
   solverBTE = ["variational","relaxons"]
   scatteringMatrixInMemory = true
   boundaryLength = 10. mum
+
+  #if using RTA or iterative solvers only, uncomment this
+  #useSymmetries = true
 
 -------------------------------------
 
@@ -240,6 +246,11 @@ Electron BTE Solver
 
 * :ref:`useSymmetries`
 
+* :ref:`numRelaxonsEigenvalues`
+
+* :ref:`checkNegativeRelaxons`
+
+
 .. raw:: html
 
   <h3>Sample input file</h3>
@@ -247,10 +258,11 @@ Electron BTE Solver
 ::
 
   appName = "electronWannierTransport"
+
   phFC2FileName = "./silicon.fc"
-  sumRuleFC2 = "crystal"
   electronH0Name = "./si_tb.dat",
   elphFileName = "silicon.phoebe.elph.dat"
+  sumRuleFC2 = "crystal"
   kMesh = [15,15,15]
   temperatures = [300.]
   dopings = [1.e21]
@@ -976,13 +988,28 @@ symmetrizeMatrix
 numRelaxonsEigenvalues
 ^^^^^^^^^^^^^^^^^^^^^^
 
-* **Description:** Compute the relaxons solver using only the ``numRelaxonsEigenvalues`` largest eigenvalues + corresponding eigenvectors. This can dramatically reduce the cost of the calculation, as the largest eigenvalues comprise most of the result. However, you have to be careful to converge the calculation with respect to this parameter as well if you use it.
+* **Description:** Compute the relaxons solver using only the ``numRelaxonsEigenvalues`` largest eigenvalues + corresponding eigenvectors. This can dramatically reduce the cost of the calculation, as the largest eigenvalues comprise most of the result. However, you have to be careful to converge the calculation with respect to this parameter as well if you use it. It's great for testing your calculation, perhaps using ~25% of the eigenvalues, with your final production result using a full calculation.
+Additionally, note that this leads to a second ScaLAPACK call to check for negative eigenvalues, which reduces the benefit of partial eigenvalue calculation. If you want to turn this off for additional cost reduction (though it's good to check this to ensure the quality of the scattering matrix) you can do so with :ref:`checkNegativeRelaxons` = false.
 
-* **Format:** *intger*
+* **Format:** *integer*
 
 * **Required:** no
 
 * **Default:** `0` (this indicates the code should compute all eigenvalues)
+
+.. _checkNegativeRelaxons:
+
+checkNegativeRelaxons
+^^^^^^^^^^^^^^^^^^^^^
+
+* **Description:** When using the relaxons solver for only ``numRelaxonsEigenvalues`` largest relaxon eigenvalues, the check for negative eigenvalues (to ensure the quality of the calculation) is done by a second ScaLAPACK call. Thoguh it's good to inspect the output of this check, if you want to turn this off, set this variable to false for additional speedup.
+
+* **Format:** *bool*
+
+* **Required:** no
+
+* **Default:** `true`
+
 
 .. _distributedElPhCoupling:
 

--- a/doc/sphinx/source/inputFiles.rst
+++ b/doc/sphinx/source/inputFiles.rst
@@ -971,6 +971,19 @@ symmetrizeMatrix
 * **Default:** `true`
 
 
+.. _numRelaxonsEigenvalues:
+
+numRelaxonsEigenvalues
+^^^^^^^^^^^^^^^^^^^^^^
+
+* **Description:** Compute the relaxons solver using only the ``numRelaxonsEigenvalues`` largest eigenvalues + corresponding eigenvectors. This can dramatically reduce the cost of the calculation, as the largest eigenvalues comprise most of the result. However, you have to be careful to converge the calculation with respect to this parameter as well if you use it.
+
+* **Format:** *intger*
+
+* **Required:** no
+
+* **Default:** `0` (this indicates the code should compute all eigenvalues)
+
 .. _distributedElPhCoupling:
 
 distributedElPhCoupling

--- a/src/algebra/Blacs.h
+++ b/src/algebra/Blacs.h
@@ -53,15 +53,15 @@ void pdsygvx_(const int *, const char*, const char*, const char*, const int*,
                 double*, int*, int*, double*, int*, int*,
                 double*, double*, double*, int*, int*, int*, double*,
                 int*, int*, int*, int*, int*, double*, int*);
-
-//  pdsyevx_(&jobz, &range, &uplo, &numRows_, mat, &ia, &ja, &descMat_[0],
-//        &vl, &vu, &il, &iu, &abstol, &m, &nz, eigenvalues, &orfac,
-//        z, iz, jz, desc_z, // need to still resolve this line
-//        work, &lwork, iwork, &liwork, ifail, iclustr, gap, &info);
+// calculate some eigenvalues of a parallel matrix of doubles
 void pdsyevx_(const char*, const char*, const char*, const int*, double*, int*, int*, int*,
-        int*, int*, int*, int*, double*, int*, int*,
+        double*, double*, int*, int*, double*, int*, int*,
         double*, double*, double*, int*, int*, int*,
         double*, int*, double*, int*, int*, int*, double*, int*);
+
+// estimate abstol for pdsyevx_
+double pdlamch_(int*, char*);
+
 }
 
 #endif /* BLACS_H */

--- a/src/algebra/Blacs.h
+++ b/src/algebra/Blacs.h
@@ -54,10 +54,11 @@ void pdsygvx_(const int *, const char*, const char*, const char*, const int*,
                 double*, double*, double*, int*, int*, int*, double*,
                 int*, int*, int*, int*, int*, double*, int*);
 // calculate some eigenvalues of a parallel matrix of doubles
-void pdsyevx_(const char*, const char*, const char*, const int*, double*, int*, int*, int*,
-        double*, double*, int*, int*, double*, int*, int*,
-        double*, double*, double*, int*, int*, int*,
-        double*, int*, double*, int*, int*, int*, double*, int*);
+void pdsyevr_(const char*, const char*, const char*, const int*, double*, int*, int*, int*,
+        double*, double*, int*, int*, int*, int*,
+        double*, double*, int*, int*, int*,
+        double*, int*, int*, int*, int*);
+
 
 // estimate abstol for pdsyevx_
 double pdlamch_(int*, char*);

--- a/src/algebra/Blacs.h
+++ b/src/algebra/Blacs.h
@@ -48,6 +48,20 @@ void pzheev_(char *, char *, int *, std::complex<double> *, int *, int *, int *,
              double *, std::complex<double> *, int *, int *, int *,
              std::complex<double> *, int *, std::complex<double> *, int *,
              int *);
+void pdsygvx_(const int *, const char*, const char*, const char*, const int*,
+                double*, int*, int*, int*, double*, int*, int*, int*, double*,
+                double*, int*, int*, double*, int*, int*,
+                double*, double*, double*, int*, int*, int*, double*,
+                int*, int*, int*, int*, int*, double*, int*);
+
+//  pdsyevx_(&jobz, &range, &uplo, &numRows_, mat, &ia, &ja, &descMat_[0],
+//        &vl, &vu, &il, &iu, &abstol, &m, &nz, eigenvalues, &orfac,
+//        z, iz, jz, desc_z, // need to still resolve this line
+//        work, &lwork, iwork, &liwork, ifail, iclustr, gap, &info);
+void pdsyevx_(const char*, const char*, const char*, const int*, double*, int*, int*, int*,
+        int*, int*, int*, int*, double*, int*, int*,
+        double*, double*, double*, int*, int*, int*,
+        double*, int*, double*, int*, int*, int*, double*, int*);
 }
 
 #endif /* BLACS_H */

--- a/src/algebra/Blacs.h
+++ b/src/algebra/Blacs.h
@@ -58,10 +58,9 @@ void pdsyevr_(const char*, const char*, const char*, const int*, double*, int*, 
         double*, double*, int*, int*, int*, int*,
         double*, double*, int*, int*, int*,
         double*, int*, int*, int*, int*);
-
-
-// estimate abstol for pdsyevx_
-double pdlamch_(int*, char*);
+// calculate all eigenvalues and vectors by divide and conquer algorithm
+void pdsyevd_(char *, char *, int *, double *, int *, int *, int *, double *,
+             double *, int *, int *, int *, double *, int *, int *, int *, int *);
 
 }
 

--- a/src/algebra/Matrix.cpp
+++ b/src/algebra/Matrix.cpp
@@ -65,7 +65,8 @@ std::tuple<std::vector<double>, Matrix<double>> Matrix<double>::diagonalize() {
 // diagonalize for only some eigenvalues
 template <>
 std::tuple<std::vector<double>, Matrix<double>>
-                        Matrix<double>::diagonalize(int numEigenvalues) {
+                        Matrix<double>::diagonalize(int numEigenvalues,
+                                        bool checkNegativeEigenvalues) {
 
   std::vector<double> eigenvalues;
   Matrix<double> eigenvectors(*this);

--- a/src/algebra/Matrix.cpp
+++ b/src/algebra/Matrix.cpp
@@ -62,6 +62,26 @@ std::tuple<std::vector<double>, Matrix<double>> Matrix<double>::diagonalize() {
   return std::make_tuple(eigenvalues, eigenvectors);
 }
 
+// diagonalize for only some eigenvalues
+template <>
+std::tuple<std::vector<double>, Matrix<double>>
+                        Matrix<double>::diagonalize(int numEigenvalues) {
+
+  std::vector<double> eigenvalues;
+  Matrix<double> eigenvectors(*this);
+
+  if(isDistributed) {
+    auto tup = pmat->diagonalize(numEigenvalues);
+    eigenvalues = std::get<0>(tup);
+    eigenvectors.pmat = &(std::get<1>(tup)); // returns a pMat, need the pointer to it
+  } else{
+    auto tup = mat->diagonalize(numEigenvalues);
+    eigenvalues = std::get<0>(tup);
+    eigenvectors.mat = &(std::get<1>(tup));
+  }
+  return std::make_tuple(eigenvalues, eigenvectors);
+}
+
 // Explicit specialization of norm for doubles
 template <>
 double Matrix<double>::norm() {

--- a/src/algebra/Matrix.h
+++ b/src/algebra/Matrix.h
@@ -156,6 +156,12 @@ class Matrix {
    */
   std::tuple<std::vector<double>, Matrix<T>> diagonalize();
 
+  /** Diagonalize a complex-hermitian / real-symmetric matrix
+   * for only some of it's eigenvalues.
+   * Nota bene: we don't check if it's hermitian/symmetric.
+   */
+  std::tuple<std::vector<double>, Matrix<T>> diagonalize(int numEigenvalues);
+
   /** Computes the squared Frobenius norm of the matrix
    * (or Euclidean norm, or L2 norm of the matrix)
    */

--- a/src/algebra/Matrix.h
+++ b/src/algebra/Matrix.h
@@ -160,7 +160,8 @@ class Matrix {
    * for only some of it's eigenvalues.
    * Nota bene: we don't check if it's hermitian/symmetric.
    */
-  std::tuple<std::vector<double>, Matrix<T>> diagonalize(int numEigenvalues);
+  std::tuple<std::vector<double>, Matrix<T>> diagonalize(int numEigenvalues,
+                                                bool checkNegativeEigenvalues = true);
 
   /** Computes the squared Frobenius norm of the matrix
    * (or Euclidean norm, or L2 norm of the matrix)

--- a/src/algebra/PMatrix.cpp
+++ b/src/algebra/PMatrix.cpp
@@ -209,4 +209,133 @@ ParallelMatrix<std::complex<double>>::diagonalize() {
   return std::make_tuple(eigenvalues_, eigenvectors);
 }
 
+// function to only compute some eigenvectors/values
+template <>
+std::tuple<std::vector<double>, ParallelMatrix<double>>
+                ParallelMatrix<double>::diagonalize(int numEigenvalues) {
+
+  if (numRows_ != numCols_) {
+    Error("Cannot diagonalize non-square matrix");
+  }
+  if ( numBlasRows_ != numBlasCols_ ) {
+    Error("Cannot diagonalize via scalapack with a non-square process grid!");
+  }
+
+  double *eigenvalues;
+  allocate(eigenvalues, numEigenvalues);
+
+  // Make a new PMatrix to receive the output
+  // check numBlocksRows etc
+  ParallelMatrix<double> eigenvectors(numEigenvalues,numEigenvalues,
+                                      numBlocksRows_,numBlocksCols_);
+  // this is tricky... we only need numEigenvalues + numEigenvalues  in mem,
+  // however, the local structure may be different if the size is different.
+
+  char jobz = 'V';  // also eigenvectors
+  char uplo = 'U';  // upper triangular
+  int ia = 1;       // row index from which we diagonalize
+  int ja = 1;       // row index from which we diagonalize
+  // global row and column index of the global matrix "Z", containined
+  // in eigenvectors.
+  int iz = 1;
+  int jz = 1;
+
+  int info = 0;
+
+  int m = 0; // filled on return with number of eigenvalues found
+  int nz = 0; // filled on return with number of eigenvectors found
+
+  char range = 'I'; // compute a range (from smallest to largest) of the eigenvalues
+  int il = numRows_ - numEigenvalues; // lower eigenvalue index
+  int iu = numEigenvalues; // higher eigenvalue index
+  int vl = 0;
+  int vu = 0; // not used unless range = V
+  double abstol = -1; // sets tolerance to epsilon(norm(T)), where norm(T) is the
+        // 1-norm of the tridiagonal matrix obtained by reducing A to tridiagonal form.
+        // Scalapack says: For most problems, this is the appropriate level of accuracy.
+
+  // https://www.ibm.com/docs/en/pessl/5.3.0?topic=easva-pdsyevx-pzheevx-selected-
+  //  eigenvalues-optionally-eigenvectors-real-symmetric-complex-hermitian-matrix
+
+  // VARIABLES related to eigenvalue orthogonalization ===============================
+  /*gap (from scalapack docs)
+  If jobz = 'V', it is vector gap, containing the gap between the eigenvalues whose
+  eigenvectors could not be reorthogonalized. The values in this vector correspond
+  to the clusters indicated by iclustr. As a result, the dot product between the
+  eigenvectors corresponding to the i-th cluster may be as high as (C)(n)/gapi,
+  where C is a small constant. */
+  // Returned as: a one-dimensional array of (at least) length (nprow)(npcol),
+  // containing numbers of the data type indicated in Table 1.
+  double *gap;
+  allocate(gap, numEigenvalues);
+  // specifies which eigenvectors should be reorthogonalized.
+  double orfac = -1; //a default value of 10-3 is used.
+  // If jobz = 'V', vector ifail is a vector telling us
+  // which of the eigenvectors were not converged
+  int *ifail;
+  allocate(ifail, numEigenvalues);
+  // If jobz = 'V', vector iclustr contains the indices of the eigenvectors
+  // corresponding to a cluster of eigenvalues that could not be reorthogonalized
+  // due to insufficient workspace.
+  int *iclustr;
+  allocate(iclustr, numEigenvalues);
+
+  // we will let pdseyv determine lwork for us. if we run it with
+  // lwork = -1 and work of length 1, it will fill work with
+  // an appropriate lwork number
+  double *work;
+  double *iwork;
+  int lwork = -1;
+  int liwork = -1; // TODO can I do both of these at once?
+  allocate(work, 1);
+  allocate(iwork, 1);
+  // TODO there's a chance desc_a is not the same, the docs vary slightly from pdsyev
+  pdsyevx_(&jobz, &range, &uplo, &numRows_, mat, &ia, &ja, &descMat_[0],
+        &vl, &vu, &il, &iu, &abstol, &m, &nz, eigenvalues, &orfac,
+        eigenvectors.mat, &iz, &jz, &eigenvectors.descMat_[0], // need to still resolve this line
+        work, &lwork, iwork, &liwork, ifail, iclustr, gap, &info);
+  lwork=int(work[0]);
+  liwork=int(iwork[0]);
+  delete[] work;
+  delete[] iwork;
+  allocate(work, lwork);
+  allocate(iwork, liwork);
+
+  // TODO oh no! we may need to revise this trick
+  // Here, we are tricking scalapack a little bit.
+  // normally, one would provide the descMat for the eigenvectors matrix
+  // as the 12th argument to pdsyev. However, this will result in an error,
+  // because the blacsContext for eigenvectors is not the exact same reference
+  // as the one for the input matrix. However, because eigenvectors is
+  // the same size and block distribution as the input matrix,
+  // there is no harm in using the same values for descMat.
+
+  // TODO there's a chance desc_a is not the same, the docs vary slightly from pdsyev
+  pdsyevx_(&jobz, &range, &uplo, &numRows_, mat, &ia, &ja, &descMat_[0],
+        &vl, &vu, &il, &iu, &abstol, &m, &nz, eigenvalues, &orfac,
+        eigenvectors.mat, &iz, &jz, &eigenvectors.descMat_[0], // need to still resolve this line
+        work, &lwork, iwork, &liwork, ifail, iclustr, gap, &info);
+
+//  pdsyev_(&jobz, &uplo, &numRows_, mat, &ia, &ja, &descMat_[0], eigenvalues,
+//          eigenvectors.mat, &ia, &ja, &descMat_[0], work, &lwork, &info);
+
+  if (info != 0) {
+    Error("PDSYEVX failed.", info);
+  }
+
+  // TODO fix this copying out
+  std::vector<double> eigenvalues_(numRows_);
+  for (int i = 0; i < numEigenvalues; i++) {
+    eigenvalues_[i] = *(eigenvalues + i);
+  }
+  delete[] eigenvalues; delete[] ifail;
+  delete[] work; delete[] iwork;
+  delete[] iclustr; delete[] gap;
+
+  // TODO? NOTE! that the scattering matrix now has different values
+
+  return std::make_tuple(eigenvalues_, eigenvectors);
+}
+
+
 #endif  // MPI_AVAIL

--- a/src/algebra/PMatrix.cpp
+++ b/src/algebra/PMatrix.cpp
@@ -212,7 +212,9 @@ ParallelMatrix<std::complex<double>>::diagonalize() {
 // function to only compute some eigenvectors/values
 template <>
 std::tuple<std::vector<double>, ParallelMatrix<double>>
-                ParallelMatrix<double>::diagonalize(int numEigenvalues) {
+                ParallelMatrix<double>::diagonalize(int numEigenvalues_) {
+
+  int numEigenvalues = numEigenvalues_;
 
   if (numRows_ != numCols_) {
     Error("Cannot diagonalize non-square matrix");
@@ -220,65 +222,70 @@ std::tuple<std::vector<double>, ParallelMatrix<double>>
   if ( numBlasRows_ != numBlasCols_ ) {
     Error("Cannot diagonalize via scalapack with a non-square process grid!");
   }
+  if ( numRows_ < numEigenvalues) {
+    numEigenvalues = numRows_;
+  }
 
+  if(mpi->mpiHead()) {
+    std::cout << "Computing first " << numEigenvalues <<
+        " eigenvalues and vectors of the scattering matrix." << std::endl;
+  }
+
+  // eigenvalue return container
   double *eigenvalues;
   allocate(eigenvalues, numEigenvalues);
 
+  // NOTE even though we only need numEigenvalues + numEigenvalues worth of z matrix,
+  // scalapack absolutely requires this matrix be the same size as the original.
+  // It's a huge waste of memory, and we should check to see if another code
+  // can get around this.
+
   // Make a new PMatrix to receive the output
-  // check numBlocksRows etc
-  ParallelMatrix<double> eigenvectors(numEigenvalues,numEigenvalues,
+  ParallelMatrix<double> eigenvectors(numRows_, numCols_,
                                       numBlocksRows_,numBlocksCols_);
-  // this is tricky... we only need numEigenvalues + numEigenvalues  in mem,
-  // however, the local structure may be different if the size is different.
 
-  char jobz = 'V';  // also eigenvectors
-  char uplo = 'U';  // upper triangular
-  int ia = 1;       // row index from which we diagonalize
-  int ja = 1;       // row index from which we diagonalize
-  // global row and column index of the global matrix "Z", containined
-  // in eigenvectors.
-  int iz = 1;
-  int jz = 1;
-
-  int info = 0;
-
-  int m = 0; // filled on return with number of eigenvalues found
-  int nz = 0; // filled on return with number of eigenvectors found
-
-  char range = 'I'; // compute a range (from smallest to largest) of the eigenvalues
-  int il = numRows_ - numEigenvalues; // lower eigenvalue index
-  int iu = numEigenvalues; // higher eigenvalue index
-  int vl = 0;
-  int vu = 0; // not used unless range = V
-  double abstol = -1; // sets tolerance to epsilon(norm(T)), where norm(T) is the
-        // 1-norm of the tridiagonal matrix obtained by reducing A to tridiagonal form.
-        // Scalapack says: For most problems, this is the appropriate level of accuracy.
-
+  // docs for this scalapack function
   // https://www.ibm.com/docs/en/pessl/5.3.0?topic=easva-pdsyevx-pzheevx-selected-
   //  eigenvalues-optionally-eigenvectors-real-symmetric-complex-hermitian-matrix
 
+  char jobz = 'V';  // also eigenvectors
+  char uplo = 'U';  // upper triangular
+  int ia = 1;       // row index of start of A
+  int ja = 1;       // col index of start of A
+  int iz = 1;       // row index of start of Z
+  int jz = 1;       // row index of start of Z
+
+  int info = 0;     // error code on return
+  int m = 0;        // filled on return with number of eigenvalues found
+  int nz = 0;       // filled on return with number of eigenvectors found
+
+  char range = 'I'; // compute a range (from smallest to largest) of the eigenvalues
+  int il = numRows_ - numEigenvalues;  // lower eigenvalue index (indexed from 1)
+  if(il == 0) il = 1;
+  int iu = numRows_;                   // higher eigenvalue index (indexed from 1)
+  double vl = -1000;             // not used unless range = V
+  double vu = 0;                 // not used unless range = V
+
   // VARIABLES related to eigenvalue orthogonalization ===============================
-  /*gap (from scalapack docs)
-  If jobz = 'V', it is vector gap, containing the gap between the eigenvalues whose
-  eigenvectors could not be reorthogonalized. The values in this vector correspond
-  to the clusters indicated by iclustr. As a result, the dot product between the
-  eigenvectors corresponding to the i-th cluster may be as high as (C)(n)/gapi,
-  where C is a small constant. */
-  // Returned as: a one-dimensional array of (at least) length (nprow)(npcol),
-  // containing numbers of the data type indicated in Table 1.
+
+  // use abstol value that gives most orthogonal eigenvectors
+  char cmach = 'S';           // used by abstol
+  double abstol = 2 * pdlamch_(&blacsContext_, &cmach);
+  //This array contains the gap between eigenvalues whose
+  //           eigenvectors could not be reorthogonalized.
   double *gap;
-  allocate(gap, numEigenvalues);
+  allocate(gap, numBlasRows_*numBlasCols_);
   // specifies which eigenvectors should be reorthogonalized.
   double orfac = -1; //a default value of 10-3 is used.
   // If jobz = 'V', vector ifail is a vector telling us
   // which of the eigenvectors were not converged
   int *ifail;
-  allocate(ifail, numEigenvalues);
+  allocate(ifail, numRows_);
   // If jobz = 'V', vector iclustr contains the indices of the eigenvectors
   // corresponding to a cluster of eigenvalues that could not be reorthogonalized
   // due to insufficient workspace.
   int *iclustr;
-  allocate(iclustr, numEigenvalues);
+  allocate(iclustr, 2*numBlasRows_*numBlasCols_);
 
   // we will let pdseyv determine lwork for us. if we run it with
   // lwork = -1 and work of length 1, it will fill work with
@@ -286,56 +293,116 @@ std::tuple<std::vector<double>, ParallelMatrix<double>>
   double *work;
   double *iwork;
   int lwork = -1;
-  int liwork = -1; // TODO can I do both of these at once?
+  int liwork = -1; // liwork seems not to be determined this way
   allocate(work, 1);
   allocate(iwork, 1);
-  // TODO there's a chance desc_a is not the same, the docs vary slightly from pdsyev
-  pdsyevx_(&jobz, &range, &uplo, &numRows_, mat, &ia, &ja, &descMat_[0],
+
+  pdsyevx_(&jobz, &range, &uplo,  &numRows_, mat, &ia, &ja, &descMat_[0],
         &vl, &vu, &il, &iu, &abstol, &m, &nz, eigenvalues, &orfac,
-        eigenvectors.mat, &iz, &jz, &eigenvectors.descMat_[0], // need to still resolve this line
+        eigenvectors.mat, &iz, &jz, &descMat_[0],
         work, &lwork, iwork, &liwork, ifail, iclustr, gap, &info);
+
   lwork=int(work[0]);
-  liwork=int(iwork[0]);
   delete[] work;
   delete[] iwork;
   allocate(work, lwork);
+
+  // for some reason, we must calculate liwork manually. The automatic
+  // determination doesn't work. Scalapack docs say:
+  // max(isizestein, isizestebz)+2n
+  //  isizestein = (n+jz-1) +2n+nprocs+1
+  //  isizestebz = max(4n, 14, nprocs)
+  int isizestein = (numRows_ + jz - 1) + 2 * numRows_ * mpi->getSize() + 1;
+  int isizestebz =  std::max(std::max(4*numRows_, 14), mpi->getSize());
+  liwork = std::max(isizestein, isizestebz)+2*numRows_;
   allocate(iwork, liwork);
 
-  // TODO oh no! we may need to revise this trick
-  // Here, we are tricking scalapack a little bit.
-  // normally, one would provide the descMat for the eigenvectors matrix
-  // as the 12th argument to pdsyev. However, this will result in an error,
-  // because the blacsContext for eigenvectors is not the exact same reference
-  // as the one for the input matrix. However, because eigenvectors is
-  // the same size and block distribution as the input matrix,
-  // there is no harm in using the same values for descMat.
-
-  // TODO there's a chance desc_a is not the same, the docs vary slightly from pdsyev
-  pdsyevx_(&jobz, &range, &uplo, &numRows_, mat, &ia, &ja, &descMat_[0],
+  // first, call and report any negative eigenvalues -------------------
+  // we want to note these for convergence reasons
+  if(mpi->mpiHead()) std::cout << "Checking for negative values" << std::endl;
+  eigenvectors = *this; // use the space of this matrix first to
+                // placehold the actual matrix, as it's changed by pdsyevx
+  range = 'V';
+  jobz = 'N';
+  vl = -1.e3;
+  vu = 0; //-1.0;
+  //vu = 0.0;
+  pdsyevx_(&jobz, &range, &uplo, &numRows_, eigenvectors.mat, &ia, &ja, &descMat_[0],
         &vl, &vu, &il, &iu, &abstol, &m, &nz, eigenvalues, &orfac,
-        eigenvectors.mat, &iz, &jz, &eigenvectors.descMat_[0], // need to still resolve this line
+        eigenvectors.mat, &iz, &jz, &descMat_[0],
         work, &lwork, iwork, &liwork, ifail, iclustr, gap, &info);
 
-//  pdsyev_(&jobz, &uplo, &numRows_, mat, &ia, &ja, &descMat_[0], eigenvalues,
-//          eigenvectors.mat, &ia, &ja, &descMat_[0], work, &lwork, &info);
+  if( m > 3 ) { // more than just the zero eigenmode was found
+    if(mpi->mpiHead()) {
+      Warning("Relaxons diagonalization found " + std::to_string(m) +
+                " in the range -1000 < eigenvalues <= 0."
+                "\nA proper relaxons solve will not have any negative eigenvalues,"
+                "\nand finding them usually indicates the calculation is unconverged."
+                "\nYou should run with more wavevectors.");
+      std::cout << "These eigenvalues are:" << std::endl;
+      for (int i = 0; i < m; i++) {
+        std::cout << i << " " << eigenvalues[i] << std::endl;
+      }
+      std::cout << std::endl;
+    }
+  }
 
-  if (info != 0) {
+  // now we perform the regular call to get the largest ones -------------
+  range = 'I';
+  jobz = 'V';
+  eigenvectors.zeros();
+
+  // We could make sure these two matrices have identical blacsContexts.
+  // However, as dim(Z) must = dim(A), we can just pass A's desc twice.
+  pdsyevx_(&jobz, &range, &uplo, &numRows_, mat, &ia, &ja, &descMat_[0],
+        &vl, &vu, &il, &iu, &abstol, &m, &nz, eigenvalues, &orfac,
+        mat, &iz, &jz, &descMat_[0],
+        work, &lwork, iwork, &liwork, ifail, iclustr, gap, &info);
+
+  if (info != 0 && mpi->mpiHead()) {
+    if(info < 0) {
+      std::cout << "Developer Error: "
+                "One of the input params to PDSYEVX is wrong!" << std::endl;
+    } else {
+      if ( (info/2 % 2) != 0 ) {
+        std::cout << "PDSYEVX had insufficient memory to "
+                        "reorthogonalize the eigenvectors." << std::endl;
+      } else if ( (info/4 % 2) != 0 ) {
+        std::cout << "PDSYEVX had insufficient memory to " <<
+                        "compute all of the eigenvectors." << std::endl;
+      } else if ( (info/8 % 2) != 0 ) {
+        std::cout << "PDSYEVX had an internal error and " <<
+                "failed to compute the eigenvalues." << std::endl;
+      }
+    }
     Error("PDSYEVX failed.", info);
   }
 
-  // TODO fix this copying out
-  std::vector<double> eigenvalues_(numRows_);
+  // copy to return containers and free the no longer used containers.
+  std::vector<double> eigenvalues_(numEigenvalues);
   for (int i = 0; i < numEigenvalues; i++) {
     eigenvalues_[i] = *(eigenvalues + i);
+    if(mpi->mpiHead()) std::cout << "eig " << i << " " << eigenvalues_[i] << std::endl;
   }
   delete[] eigenvalues; delete[] ifail;
   delete[] work; delete[] iwork;
   delete[] iclustr; delete[] gap;
 
-  // TODO? NOTE! that the scattering matrix now has different values
+  ParallelMatrix<double> returnEigenvectors(numRows_, numEigenvalues,
+                                                numBlocksRows_, numBlocksCols_);
+  // TODO copy in here
 
-  return std::make_tuple(eigenvalues_, eigenvectors);
+    for (auto tup0 : eigenvectors.getAllLocalStates()) {
+      int is = std::get<0>(tup0);
+      int alpha = std::get<1>(tup0);
+      if(alpha < numEigenvalues)
+        std::cout << "eigenvec " << is << " " << alpha << " " << eigenvectors(is, alpha) << std::endl;
+    }
+
+  // note that the scattering matrix now has different values
+  // it's going to be the upper triangle and diagonal of A
+
+  return std::make_tuple(eigenvalues_, returnEigenvectors);
 }
-
 
 #endif  // MPI_AVAIL

--- a/src/algebra/PMatrix.h
+++ b/src/algebra/PMatrix.h
@@ -20,6 +20,9 @@ using ParallelMatrix = SerialMatrix<T>;
 #include <utility>
 #include <set>
 
+// https://www.ibm.com/docs/en/pessl/5.5?topic=programs-application-program-outline
+// TODO we could remove the sq proc grid requirement as done here
+
 /** Class for managing a matrix MPI-distributed in memory.
  *
  * This class uses the Scalapack library for matrix-matrix multiplication and

--- a/src/algebra/PMatrix.h
+++ b/src/algebra/PMatrix.h
@@ -205,6 +205,7 @@ class ParallelMatrix {
    * By default, it operates on the upper-triangular part of the matrix.
    */
   std::tuple<std::vector<double>, ParallelMatrix<T>> diagonalize();
+  std::tuple<std::vector<double>, ParallelMatrix<T>> diagonalize(int numEigenvalues);
 
   /** Computes the squared Frobenius norm of the matrix
    * (or Euclidean norm, or L2 norm of the matrix)

--- a/src/algebra/PMatrix.h
+++ b/src/algebra/PMatrix.h
@@ -66,6 +66,9 @@ class ParallelMatrix {
   std::tuple<int, int> local2Global(const int& k) const;
   std::tuple<int, int> local2Global(const int& i, const int& j) const;
 
+  /** Set the blacsContext for cases where two descriptors must share the same one */
+  void setBlacsContext(int blacsContext);
+
  public:
   /** Converts a global row/column index of the global matrix into a local
    * one-dimensional storage index (MPI-dependent),
@@ -86,7 +89,8 @@ class ParallelMatrix {
    * @param numBLocksCols: column size of the block for Blacs distribution
    */
   ParallelMatrix(const int& numRows, const int& numCols,
-                 const int& numBlocksRows = 0, const int& numBlocksCols = 0);
+                 const int& numBlocksRows = 0, const int& numBlocksCols = 0,
+                 const int& blacsContext = -1);
 
   /** Empty constructor
    */
@@ -110,7 +114,8 @@ class ParallelMatrix {
   * If both are zero, this function falls back to create a square
   * blacs process grid.
   */
-  void initBlacs(const int& numBlasRows = 0, const int& numBlasCols = 0);
+  void initBlacs(const int& numBlasRows = 0, const int& numBlasCols = 0,
+                                                const int& initBlacsContext = -1);
 
   /** Find the global indices of the matrix elements that are stored locally
    * by the current MPI process.
@@ -231,14 +236,15 @@ class ParallelMatrix {
 template <typename T>
 ParallelMatrix<T>::ParallelMatrix(const int& numRows, const int& numCols,
                                   const int& numBlocksRows,
-                                  const int& numBlocksCols) {
+                                  const int& numBlocksCols,
+                                  const int& blacsContext) {
 
   // call initBlacs to set all blacs related variables and contruct
   // the blacs context and process grid setup.
   // If numBlocksRows or numBlocksCols is not zero, this will
   // initialize blacs with a square process grid
   // (and number of processors must be a square number)
-  initBlacs(numBlocksRows,numBlocksCols);
+  initBlacs(numBlocksRows, numBlocksCols, blacsContext);
 
   // initialize number of rows and columns of the global matrix
   numRows_ = numRows;
@@ -280,6 +286,7 @@ ParallelMatrix<T>::ParallelMatrix(const int& numRows, const int& numCols,
 
   descinit_(descMat_, &numRows_, &numCols_, &blockSizeRows_, &blockSizeCols_,
             &iZero, &iZero, &blacsContext_, &lddA, &info);
+
   if (info != 0) {
     Error("Something wrong calling descinit", info);
   }
@@ -381,17 +388,27 @@ ParallelMatrix<T>::~ParallelMatrix() {
 }
 
 template <typename T>
-void ParallelMatrix<T>::initBlacs(const int& numBlasRows, const int& numBlasCols) {
+void ParallelMatrix<T>::initBlacs(const int& numBlasRows, const int& numBlasCols,
+                                                        const int& inputBlacsContext) {
 
   int size = mpi->getSize(); // temp variable for mpi world size, used in setup
 
+  // TODO if we only give this the nearest square number of processors,
+  // will it disregard the others for us? Could this fix the
+  // sq process thing?
+  //       NPROW = INT(SQRT(REAL(NNODES)))
+  //    NPCOL = NNODES/NPROW
+  //  IF (MYROW .LT. NPROW .AND. MYCOL .LT. NPCOL) THEN
+  //  https://www.ibm.com/docs/en/pessl/5.5?topic=programs-application-program-outline
   blacs_pinfo_(&blasRank_, &size);
   int iZero = 0;
-  blacs_get_(&iZero, &iZero, &blacsContext_);  // -> Create context
+  if( inputBlacsContext == -1) { // no context has been created/supplied
+    blacs_get_(&iZero, &iZero, &blacsContext_);  // -> get default system context
+  }
 
   // kill the code if we asked for more blas rows/cols than there are procs
   if (mpi->getSize() < numBlasRows * numBlasCols) {
-     Error("initBlacs requested too many MPI processes.");
+     Error("Developer error: initBlacs requested too many MPI processes.");
   }
 
   // Cases for a blacs grid where we specified rows, cols, both,
@@ -418,9 +435,13 @@ void ParallelMatrix<T>::initBlacs(const int& numBlasRows, const int& numBlasCols
       Error("Phoebe needs a square number of MPI processes");
     }
   }
-
-  blacs_gridinit_(&blacsContext_, &blacsLayout_, &numBlasRows_,
-                    &numBlasCols_);
+  // if no context is given, create one.
+  // Otherwise, use the one supplied
+  if( inputBlacsContext == -1) { // no context has been created/supplied
+    blacs_gridinit_(&blacsContext_, &blacsLayout_, &numBlasRows_, &numBlasCols_);
+  } else {
+    blacsContext_ = inputBlacsContext;
+  }
   // Context -> Context grid info (# procs row/col, current procs row/col)
   blacs_gridinfo_(&blacsContext_, &numBlasRows_, &numBlasCols_, &myBlasRow_,
                     &myBlasCol_);
@@ -665,6 +686,11 @@ ParallelMatrix<T> ParallelMatrix<T>::operator-() const {
     *(result.mat + i) = -*(result.mat + i);
   }
   return result;
+}
+// function to make sure two matrices share a blacs context...
+template <typename T>
+void ParallelMatrix<T>::setBlacsContext(int blacsContext) {
+  blacsContext_ = blacsContext;
 }
 
 #endif  // include safeguard

--- a/src/algebra/PMatrix.h
+++ b/src/algebra/PMatrix.h
@@ -214,7 +214,8 @@ class ParallelMatrix {
    * By default, it operates on the upper-triangular part of the matrix.
    */
   std::tuple<std::vector<double>, ParallelMatrix<T>> diagonalize();
-  std::tuple<std::vector<double>, ParallelMatrix<T>> diagonalize(int numEigenvalues);
+  std::tuple<std::vector<double>, ParallelMatrix<T>> diagonalize(int numEigenvalues,
+                                                bool checkNegativeEigenvalues = true);
 
   /** Computes the squared Frobenius norm of the matrix
    * (or Euclidean norm, or L2 norm of the matrix)

--- a/src/algebra/SMatrix.cpp
+++ b/src/algebra/SMatrix.cpp
@@ -89,6 +89,15 @@ std::tuple<std::vector<double>, SerialMatrix<double>> SerialMatrix<double>::diag
   return std::make_tuple(eigenvalues, eigenvectors);
 }
 
+template <>
+std::tuple<std::vector<double>, SerialMatrix<double>>
+                        SerialMatrix<double>::diagonalize([[maybe_unused]] int numEigenvalues) {
+
+    Warning("Partial eigenvalue diagonalization currently not implemented "
+                "for the serial case. Reporting all eigenvalues.");
+    diagonalize();
+}
+
 // Explicit specialization of norm for doubles
 template <>
 double SerialMatrix<double>::norm() {

--- a/src/algebra/SMatrix.cpp
+++ b/src/algebra/SMatrix.cpp
@@ -91,7 +91,8 @@ std::tuple<std::vector<double>, SerialMatrix<double>> SerialMatrix<double>::diag
 
 template <>
 std::tuple<std::vector<double>, SerialMatrix<double>>
-                        SerialMatrix<double>::diagonalize([[maybe_unused]] int numEigenvalues) {
+                        SerialMatrix<double>::diagonalize([[maybe_unused]] int numEigenvalues,
+                                [[maybe_unused]] bool checkNegativeEigenvalues) {
 
     Warning("Partial eigenvalue diagonalization currently not implemented "
                 "for the serial case. Reporting all eigenvalues.");

--- a/src/algebra/SMatrix.h
+++ b/src/algebra/SMatrix.h
@@ -49,8 +49,9 @@ class SerialMatrix {
    * @param numBlocksRows, numBlocksCols: these parameters are ignored and are
    * put here for mirroring the interface of ParallelMatrix.
    */
-  SerialMatrix(const int& numRows, const int& numCols, const int& numBlocksRows = 0,
-         const int& numBlocksCols = 0);
+  SerialMatrix(const int& numRows, const int& numCols,
+                 const int& numBlasRows = 0, const int& numBlasCols = 0,
+                 const int& numBlocksRows = 0, const int& numBlocksCols = 0);
 
   /** Default constructor
    */
@@ -188,9 +189,14 @@ class SerialMatrix {
 // A default constructor to build a dense matrix of zeros to be filled
 template <typename T>
 SerialMatrix<T>::SerialMatrix(const int& numRows, const int& numCols,
+                  const int& numBlasRows, const int& numBlasCols,
                   const int& numBlocksRows, const int& numBlocksCols) {
+  // these are used only the in the pmatrix case
   (void) numBlocksRows;
   (void) numBlocksCols;
+  (void) numBlasRows;
+  (void) numBlasCols;
+
   numRows_ = numRows;
   numCols_ = numCols;
   numElements_ = numRows_ * numCols_;

--- a/src/algebra/SMatrix.h
+++ b/src/algebra/SMatrix.h
@@ -158,6 +158,12 @@ class SerialMatrix {
    */
   std::tuple<std::vector<double>, SerialMatrix<T>> diagonalize();
 
+  /** Diagonalize a complex-hermitian / real sym matrix
+   * for only some of its eigenvalues.
+   * Note: this isn't implemented for now and just calls the diagonalize() function
+   */
+  std::tuple<std::vector<double>, SerialMatrix<T>> diagonalize(int numEigenvalues);
+
   /** Computes the squared Frobenius norm of the matrix
    * (or Euclidean norm, or L2 norm of the matrix)
    */

--- a/src/algebra/SMatrix.h
+++ b/src/algebra/SMatrix.h
@@ -163,7 +163,8 @@ class SerialMatrix {
    * for only some of its eigenvalues.
    * Note: this isn't implemented for now and just calls the diagonalize() function
    */
-  std::tuple<std::vector<double>, SerialMatrix<T>> diagonalize(int numEigenvalues);
+  std::tuple<std::vector<double>, SerialMatrix<T>> diagonalize(int numEigenvalues,
+                                                bool checkNegativeEigenvalues = true);
 
   /** Computes the squared Frobenius norm of the matrix
    * (or Euclidean norm, or L2 norm of the matrix)

--- a/src/apps/electron_wannier_transport_app.cpp
+++ b/src/apps/electron_wannier_transport_app.cpp
@@ -469,7 +469,7 @@ void ElectronWannierTransportApp::runIterativeMethod(
 
   VectorBTE lineWidths = scatteringMatrix.getLinewidths();
 
-  // we get the symmetrized
+  // we get the symmetrized drift vectors
   BulkEDrift driftE(statisticsSweep, bandStructure, 3, true);
   BulkTDrift driftT(statisticsSweep, bandStructure, 3, true);
   VectorBTE relaxationTimes = scatteringMatrix.getSingleModeTimes();

--- a/src/apps/electron_wannier_transport_app.cpp
+++ b/src/apps/electron_wannier_transport_app.cpp
@@ -167,7 +167,6 @@ void ElectronWannierTransportApp::run(Context &context) {
         // A -> ( A^T + A ) / 2
         // this helps removing negative eigenvalues which may appear due to noise
         scatteringMatrix.symmetrize();
-        // it may not be necessary, so it's commented out
       }
     }
   }
@@ -187,9 +186,10 @@ void ElectronWannierTransportApp::run(Context &context) {
       std::cout << "Starting relaxons BTE solver" << std::endl;
     }
     // scatteringMatrix.a2Omega(); Important!! Must use the matrix A, non-scaled
-    // this because the scaling used for phonons here would cause instability
+    // this is because the scaling used for phonons here would cause instability
     // as it could contains factors like 1/0
-    auto tup = scatteringMatrix.diagonalize();
+    auto tup = scatteringMatrix.diagonalize(context.getNumRelaxonsEigenvalues());
+
     Eigen::VectorXd eigenvalues = std::get<0>(tup);
     ParallelMatrix<double> eigenvectors = std::get<1>(tup);
     // EV such that Omega = V D V^-1

--- a/src/apps/electron_wannier_transport_app.cpp
+++ b/src/apps/electron_wannier_transport_app.cpp
@@ -201,7 +201,6 @@ void ElectronWannierTransportApp::run(Context &context) {
     scatteringMatrix.relaxonsToJSON("exact_relaxation_times.json", eigenvalues);
 
     if (!context.getUseSymmetries()) {
-      // Vector0 fermiEigenvector(statisticsSweep, bandStructure, specificHeat, true);
       elViscosity.calcFromRelaxons(eigenvalues, eigenvectors);
       elViscosity.print();
       elViscosity.outputToJSON("relaxons_electron_viscosity.json");

--- a/src/apps/phonon_transport_app.cpp
+++ b/src/apps/phonon_transport_app.cpp
@@ -147,8 +147,7 @@ void PhononTransportApp::run(Context &context) {
     std::cout << "\n" << std::string(80, '-') << "\n" << std::endl;
   }
 
-  // if requested, we solve the BTE exactly
-
+  // if requested, we solve the BTE exactly -----------------------------
   std::vector<std::string> solverBTE = context.getSolverBTE();
 
   bool doIterative = false;
@@ -191,7 +190,6 @@ void PhononTransportApp::run(Context &context) {
         // A -> ( A^T + A ) / 2
         // this helps removing negative eigenvalues which may appear due to noise
         scatteringMatrix.symmetrize();
-        // it may not be necessary, so it's commented out
       }
     }
   }
@@ -386,27 +384,30 @@ void PhononTransportApp::run(Context &context) {
     if (mpi->mpiHead()) {
       std::cout << "Starting relaxons BTE solver" << std::endl;
     }
-
     scatteringMatrix.a2Omega();
 
-    auto tup2 = scatteringMatrix.diagonalize();
+    // NOTE: scattering matrix is destroyed in this process, do not use it afterwards!
+    auto tup2 = scatteringMatrix.diagonalize(context.getNumRelaxonsEigenvalues());
     auto eigenvalues = std::get<0>(tup2);
     auto eigenvectors = std::get<1>(tup2);
     // EV such that Omega = V D V^-1
     // eigenvectors(phonon index, eigenvalue index)
 
+    // TODO what is the scattering matrix doing here
     phTCond.calcFromRelaxons(context, statisticsSweep, eigenvectors,
                              scatteringMatrix, eigenvalues);
     phTCond.print();
     phTCond.outputToJSON("relaxons_phonon_thermal_cond.json");
+
     // output relaxation times
-    scatteringMatrix.relaxonsToJSON("relaxons_relaxation_times.json",
-                                    eigenvalues);
+    scatteringMatrix.relaxonsToJSON("relaxons_relaxation_times.json", eigenvalues);
 
     if (!context.getUseSymmetries()) {
-      Vector0 boseEigenvector(statisticsSweep, bandStructure, specificHeat);
-      phViscosity.calcFromRelaxons(boseEigenvector, eigenvalues,
-                                   scatteringMatrix, eigenvectors);
+      // Note: Andrea originally supplied the boseEigenvector, however,
+      // it appears to go unused in phViscosity.
+      //Vector0 boseEigenvector(statisticsSweep, bandStructure, specificHeat);
+      //phViscosity.calcFromRelaxons(boseEigenvector, eigenvalues, eigenvectors);
+      phViscosity.calcFromRelaxons(eigenvalues, eigenvectors);
       phViscosity.print();
       phViscosity.outputToJSON("relaxons_phonon_viscosity.json");
     }

--- a/src/apps/phonon_transport_app.cpp
+++ b/src/apps/phonon_transport_app.cpp
@@ -403,10 +403,6 @@ void PhononTransportApp::run(Context &context) {
     scatteringMatrix.relaxonsToJSON("relaxons_relaxation_times.json", eigenvalues);
 
     if (!context.getUseSymmetries()) {
-      // Note: Andrea originally supplied the boseEigenvector, however,
-      // it appears to go unused in phViscosity.
-      //Vector0 boseEigenvector(statisticsSweep, bandStructure, specificHeat);
-      //phViscosity.calcFromRelaxons(boseEigenvector, eigenvalues, eigenvectors);
       phViscosity.calcFromRelaxons(eigenvalues, eigenvectors);
       phViscosity.print();
       phViscosity.outputToJSON("relaxons_phonon_viscosity.json");

--- a/src/bands/active_bandstructure.cpp
+++ b/src/bands/active_bandstructure.cpp
@@ -79,7 +79,7 @@ ActiveBandStructure::ActiveBandStructure(const Points &points_,
 
   // store the full list of points for later use
 #pragma omp parallel for
-  for (size_t iik = 0; iik < niks; iik++) {
+  for (size_t iik = 0; iik < size_t(niks); iik++) {
     size_t ik = iks[iik];
     Point point = points.getPoint(ik);
     Eigen::Vector3d q = point.getCoordinates(Points::cartesianCoordinates);
@@ -119,7 +119,7 @@ ActiveBandStructure::ActiveBandStructure(const Points &points_,
       Eigen::VectorXd energies(numBands);
       Eigen::MatrixXcd eigenvectors(numBands, numBands);
 #pragma omp for
-      for (size_t iik = 0; iik < stop_iik-start_iik; iik++) {
+      for (size_t iik = 0; iik < size_t(stop_iik-start_iik); iik++) {
         size_t ik = iks[start_iik+iik];
         Point point = points.getPoint(ik);
 
@@ -165,7 +165,7 @@ ActiveBandStructure::ActiveBandStructure(const Points &points_,
         int numBands = velocities_h.extent(1);;
         Eigen::Tensor<std::complex<double>,3> velocities(numBands, numBands,3);
 #pragma omp for
-        for (size_t iik = 0; iik < stop_iik-start_iik; iik++) {
+        for (size_t iik = 0; iik < size_t(stop_iik-start_iik); iik++) {
           size_t ik = iks[start_iik+iik];
           Point point = points.getPoint(ik);
 

--- a/src/bte/scattering.cpp
+++ b/src/bte/scattering.cpp
@@ -856,7 +856,7 @@ ScatteringMatrix::diagonalize(int numEigenvalues) {
   std::tuple<std::vector<double>, ParallelMatrix<double>> tup;
   if(numEigenvalues > numStates) { // not possible
     Error("You have requested to calculate more relaxons eigenvalues"
-        " than your number of phonon states.");
+        " than your number of particle states.");
   }
   if(numEigenvalues > 0 && numEigenvalues != numStates) { // zero is default, calculates all of them
     // calculate some of the eigenvalues

--- a/src/bte/scattering.cpp
+++ b/src/bte/scattering.cpp
@@ -133,15 +133,13 @@ void ScatteringMatrix::setup() {
       // There may be logic to how to choose these sizes,
       // but for now I cannot find advice on this online.
 
-      // As an additional note, if the matrix is very small, we need to scale
-      // the blocksize accordingly to avoid scalapack throwing an error
-      int nBlocks = int(matSize/64);
-      // TODO this is a bit of a mystery, but it seems that scalapack can
-      // have an error if the matrix is very small and the blocksize is big by comparison...
-      // Should we move this to PMatrix constructor instead?
-      if(nBlocks < mpi->getSize()) {
-        nBlocks = int(sqrt(matSize));
-      }
+      int nBlocks = int(matSize/64.);
+      // TODO Should we move this to PMatrix constructor instead?
+      // seems tiny number of blocks is a problem, but it should
+      // only come up for very tiny cases where speed is not an issue,
+      // therefore, we default to 4 blocks if this happens.
+      // Seems like this is maybe a bug in scalapack?
+      if(nBlocks < 4) nBlocks = 4;
 
       theMatrix = ParallelMatrix<double>(matSize, matSize, 0, 0, nBlocks, nBlocks);
 

--- a/src/bte/scattering.cpp
+++ b/src/bte/scattering.cpp
@@ -882,7 +882,7 @@ ScatteringMatrix::diagonalize(int numEigenvalues) {
   }
   if(numEigenvalues > 0 && numEigenvalues != numStates) { // zero is default, calculates all of them
     // calculate some of the eigenvalues
-    tup = theMatrix.diagonalize(numEigenvalues);
+    tup = theMatrix.diagonalize(numEigenvalues, context.getCheckNegativeRelaxons());
   } else { // calculate all
     tup = theMatrix.diagonalize();
   }

--- a/src/bte/scattering.cpp
+++ b/src/bte/scattering.cpp
@@ -837,7 +837,7 @@ void ScatteringMatrix::relaxonsToJSON(const std::string &outFileName,
 }
 
 std::tuple<Eigen::VectorXd, ParallelMatrix<double>>
-ScatteringMatrix::diagonalize() {
+ScatteringMatrix::diagonalize(int numEigenvalues) {
 
   // user info about memory
   {
@@ -852,13 +852,23 @@ ScatteringMatrix::diagonalize() {
                 << std::endl;
     }
   }
-
-  auto tup = theMatrix.diagonalize();
+  // diagonalize
+  std::tuple<std::vector<double>, ParallelMatrix<double>> tup;
+  if(numEigenvalues > numStates) { // not possible
+    Error("You have requested to calculate more relaxons eigenvalues"
+        " than your number of phonon states.");
+  }
+  if(numEigenvalues > 0 && numEigenvalues != numStates) { // zero is default, calculates all of them
+    // calculate some of the eigenvalues
+    tup = theMatrix.diagonalize(numEigenvalues);
+  } else { // calculate all
+    tup = theMatrix.diagonalize();
+  }
   auto eigenvalues = std::get<0>(tup);
   auto eigenvectors = std::get<1>(tup);
 
   // place eigenvalues in an VectorBTE object
-  Eigen::VectorXd eigenValues(theMatrix.rows());
+  Eigen::VectorXd eigenValues(eigenvalues.size());
   for (int is = 0; is < eigenValues.size(); is++) {
     eigenValues(is) = eigenvalues[is];
   }

--- a/src/bte/scattering.h
+++ b/src/bte/scattering.h
@@ -116,11 +116,14 @@ public:
 //  void omega2A();
 
   /** Diagonalize the scattering matrix
+   * @param numEigenvalues: if a number is supplied, calculate
+   *                only the first few of these points
    * @return eigenvalues: a Eigen::VectorXd with the eigenvalues
    * @return eigenvectors: a Eigen::MatrixXd with the eigenvectors
    * Eigenvectors are aligned on rows: eigenvectors(qpState,eigenIndex)
    */
-  std::tuple<Eigen::VectorXd, ParallelMatrix<double>> diagonalize();
+  std::tuple<Eigen::VectorXd, ParallelMatrix<double>>
+                                diagonalize(int numEigenvalues = 0);
 
   /** Outputs the quantity to a json file.
    * @param outFileName: string representing the name of the json file

--- a/src/bte/scattering.h
+++ b/src/bte/scattering.h
@@ -189,7 +189,7 @@ public:
   // Smearing is a pointer created in constructor with a smearing factory
   // Used in the construction of the scattering matrix to approximate the
   // Dirac-delta function in transition rates.
-  //DeltaFunction *smearing; // moved to specific ph and el base scatteringMatrix objs
+  DeltaFunction *smearing;
 
   BaseBandStructure &innerBandStructure;
   BaseBandStructure &outerBandStructure;

--- a/src/bte/scattering.h
+++ b/src/bte/scattering.h
@@ -189,7 +189,7 @@ public:
   // Smearing is a pointer created in constructor with a smearing factory
   // Used in the construction of the scattering matrix to approximate the
   // Dirac-delta function in transition rates.
-  DeltaFunction *smearing;
+  //DeltaFunction *smearing; // moved to specific ph and el base scatteringMatrix objs
 
   BaseBandStructure &innerBandStructure;
   BaseBandStructure &outerBandStructure;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -644,6 +644,10 @@ void Context::setupFromInput(const std::string &fileName) {
         numRelaxonsEigenvalues = parseInt(val);
       }
 
+      if (parameterName == "checkNegativeRelaxons") {
+        checkNegativeRelaxons = parseBool(val);
+      }
+
       if (parameterName == "useSymmetries") {
         useSymmetries = parseBool(val);
       }
@@ -1269,6 +1273,8 @@ int Context::getNumRelaxonsEigenvalues() const {
 void Context::setNumRelaxonsEigenvalues(const int &x) {
   numRelaxonsEigenvalues = x;
 }
+
+bool Context::getCheckNegativeRelaxons() const { return checkNegativeRelaxons; }
 
 bool Context::getUseSymmetries() const { return useSymmetries; }
 void Context::setUseSymmetries(const bool &x) { useSymmetries = x; }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -640,6 +640,10 @@ void Context::setupFromInput(const std::string &fileName) {
         symmetrizeMatrix = parseBool(val);
       }
 
+      if (parameterName == "numRelaxonsEigenvalues") {
+        numRelaxonsEigenvalues = parseInt(val);
+      }
+
       if (parameterName == "useSymmetries") {
         useSymmetries = parseBool(val);
       }
@@ -1257,6 +1261,13 @@ bool Context::getSymmetrizeMatrix() const {
 }
 void Context::setSymmetrizeMatrix(const bool &x) {
   symmetrizeMatrix = x;
+}
+
+int Context::getNumRelaxonsEigenvalues() const {
+  return numRelaxonsEigenvalues;
+}
+void Context::setNumRelaxonsEigenvalues(const int &x) {
+  numRelaxonsEigenvalues = x;
 }
 
 bool Context::getUseSymmetries() const { return useSymmetries; }

--- a/src/context.h
+++ b/src/context.h
@@ -119,6 +119,9 @@ class Context {
   // if true, enforce the symmetrization of the scattering matrix
   bool symmetrizeMatrix = true;
 
+  // number of eigenvalues to use the in the relaxons solver
+  int numRelaxonsEigenvalues = 0;
+
   int hdf5ElphFileFormat = 1;
   std::string wsVecFileName;
 public:
@@ -344,6 +347,9 @@ public:
 
   bool getSymmetrizeMatrix() const;
   void setSymmetrizeMatrix(const bool &x);
+
+  int getNumRelaxonsEigenvalues() const;
+  void setNumRelaxonsEigenvalues(const int &x);
 
   int getHdf5ElPhFileFormat() const;
   void setHdf5ElPhFileFormat(const int &x);

--- a/src/context.h
+++ b/src/context.h
@@ -121,6 +121,8 @@ class Context {
 
   // number of eigenvalues to use the in the relaxons solver
   int numRelaxonsEigenvalues = 0;
+  // toggle the check for negative relaxons eigenvalues in few eigenvalues case
+  bool checkNegativeRelaxons = true;
 
   int hdf5ElphFileFormat = 1;
   std::string wsVecFileName;
@@ -350,6 +352,8 @@ public:
 
   int getNumRelaxonsEigenvalues() const;
   void setNumRelaxonsEigenvalues(const int &x);
+
+  bool getCheckNegativeRelaxons() const;
 
   int getHdf5ElPhFileFormat() const;
   void setHdf5ElPhFileFormat(const int &x);

--- a/src/observable/electron_viscosity.cpp
+++ b/src/observable/electron_viscosity.cpp
@@ -162,6 +162,7 @@ tensordxdxdxd = tensordxdxdxd + tmpTensor;
   }
 void ElectronViscosity::calcFromRelaxons(Eigen::VectorXd &eigenvalues,
     ParallelMatrix<double> &eigenvectors) {
+
   if (numCalculations > 1) {
     Error("Developer error: Electron viscosity cannot be calculated for more than one T.");
   }

--- a/src/observable/onsager.cpp
+++ b/src/observable/onsager.cpp
@@ -411,7 +411,6 @@ void OnsagerCoefficients::calcFromRelaxons(
     mpi->allReduceSum(&fE);
 
     // back rotate to Bloch electron coordinates
-
     for (auto tup0 : eigenvectors.getAllLocalStates()) {
       int iMat1 = std::get<0>(tup0);
       int alpha = std::get<1>(tup0);

--- a/src/observable/onsager.cpp
+++ b/src/observable/onsager.cpp
@@ -320,6 +320,9 @@ void OnsagerCoefficients::calcTransportCoefficients() {
 void OnsagerCoefficients::calcFromRelaxons(
     Eigen::VectorXd &eigenvalues, ParallelMatrix<double> &eigenvectors,
     ElScatteringMatrix &scatteringMatrix) {
+
+  int numEigenvalues = eigenvalues.size();
+
   int iCalc = 0;
   double chemPot = statisticsSweep.getCalcStatistics(iCalc).chemicalPotential;
   double temp = statisticsSweep.getCalcStatistics(iCalc).temperature;
@@ -332,20 +335,26 @@ void OnsagerCoefficients::calcFromRelaxons(
 
     VectorBTE fE(statisticsSweep, bandStructure, 3);
     VectorBTE fT(statisticsSweep, bandStructure, 3);
+
     for (auto tup0 : eigenvectors.getAllLocalStates()) {
       int is = std::get<0>(tup0);
-      int alfa = std::get<1>(tup0);
-      if (eigenvalues(alfa) <= 0.) {
+      int alpha = std::get<1>(tup0);
+      // if we only calculated some eigenvalues,
+      // we should not include any alpha
+      // values past that -- the memory in eigenvectors is
+      // still allocated, however, it contains zeros or nonsense.
+      // we also need to discard any negative states (warned about already)
+      if (eigenvalues(alpha) <= 0. || alpha >= numEigenvalues) {
         continue;
       }
       auto isIndex = StateIndex(is);
       double en = bandStructure.getEnergy(isIndex);
       auto vel = bandStructure.getGroupVelocity(isIndex);
       for (int i : {0, 1, 2}) {
-        fE(iCalc, i, alfa) += -particle.getDnde(en, temp, chemPot, true)
-            * vel(i) * eigenvectors(is, alfa) / eigenvalues(alfa);
-        fT(iCalc, i, alfa) += -particle.getDndt(en, temp, chemPot, true)
-            * vel(i) * eigenvectors(is, alfa) / eigenvalues(alfa);
+        fE(iCalc, i, alpha) += -particle.getDnde(en, temp, chemPot, true)
+            * vel(i) * eigenvectors(is, alpha) / eigenvalues(alpha);
+        fT(iCalc, i, alpha) += -particle.getDndt(en, temp, chemPot, true)
+            * vel(i) * eigenvectors(is, alpha) / eigenvalues(alpha);
       }
     }
     mpi->allReduceSum(&fE.data);
@@ -353,10 +362,14 @@ void OnsagerCoefficients::calcFromRelaxons(
 
     for (auto tup0 : eigenvectors.getAllLocalStates()) {
       int is = std::get<0>(tup0);
-      int alfa = std::get<1>(tup0);
+      int alpha = std::get<1>(tup0);
+      // discard negative and non-computed alpha values
+      if (eigenvalues(alpha) <= 0. || alpha >= numEigenvalues) {
+        continue;
+      }
       for (int i : {0, 1, 2}) {
-        nE(iCalc, i, is) += fE(iCalc, i, alfa) * eigenvectors(is, alfa);
-        nT(iCalc, i, is) += fT(iCalc, i, alfa) * eigenvectors(is, alfa);
+        nE(iCalc, i, is) += fE(iCalc, i, alpha) * eigenvectors(is, alpha);
+        nT(iCalc, i, is) += fT(iCalc, i, alpha) * eigenvectors(is, alpha);
       }
     }
     mpi->allReduceSum(&nE.data);
@@ -371,6 +384,10 @@ void OnsagerCoefficients::calcFromRelaxons(
     for (auto tup0 : eigenvectors.getAllLocalStates()) {
       int iMat1 = std::get<0>(tup0);
       int alpha = std::get<1>(tup0);
+      // discard negative and non-computed alpha values
+      if (eigenvalues(alpha) <= 0. || alpha >= numEigenvalues) {
+        continue;
+      }
       auto tup1 = scatteringMatrix.getSMatrixIndex(iMat1);
       BteIndex iBteIndex = std::get<0>(tup1);
       CartIndex dimIndex = std::get<1>(tup1);
@@ -398,6 +415,10 @@ void OnsagerCoefficients::calcFromRelaxons(
     for (auto tup0 : eigenvectors.getAllLocalStates()) {
       int iMat1 = std::get<0>(tup0);
       int alpha = std::get<1>(tup0);
+      // discard negative and non-computed alpha values
+      if (eigenvalues(alpha) <= 0. || alpha >= numEigenvalues) {
+        continue;
+      }
       auto tup1 = scatteringMatrix.getSMatrixIndex(iMat1);
       BteIndex iBteIndex = std::get<0>(tup1);
       CartIndex dimIndex = std::get<1>(tup1);

--- a/src/observable/onsager.cpp
+++ b/src/observable/onsager.cpp
@@ -376,7 +376,7 @@ void OnsagerCoefficients::calcFromRelaxons(
     mpi->allReduceSum(&nT.data);
 
   } else { // with symmetries
-    Error("Not sure relaxons with symmetries would work");
+    Error("Developer error: Theoretically, relaxons with symmetries may not work.");
     Eigen::MatrixXd fE(3, eigenvectors.cols());
     Eigen::MatrixXd fT(3, eigenvectors.cols());
     fE.setZero();

--- a/src/observable/phonon_thermal_cond.cpp
+++ b/src/observable/phonon_thermal_cond.cpp
@@ -428,7 +428,7 @@ void PhononThermalConductivity::calcFromRelaxons(
       }
     }
   }
-  // now calculate the thermal conductivity using the relaxons population
+  // now calculate the thermal conductivity using the standard phonon population
   calcFromPopulation(population);
 }
 

--- a/src/observable/phonon_thermal_cond.cpp
+++ b/src/observable/phonon_thermal_cond.cpp
@@ -49,6 +49,7 @@ void PhononThermalConductivity::calcFromCanonicalPopulation(VectorBTE &f) {
 }
 
 void PhononThermalConductivity::calcFromPopulation(VectorBTE &n) {
+
   double norm = 1. / context.getQMesh().prod() /
                 crystal.getVolumeUnitCell(dimensionality);
 
@@ -62,6 +63,7 @@ void PhononThermalConductivity::calcFromPopulation(VectorBTE &n) {
   Kokkos::View<double***, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> tensordxd_k(tensordxd.data(), numCalculations, 3, 3);
   Kokkos::Experimental::ScatterView<double***, Kokkos::LayoutLeft, Kokkos::HostSpace> scatter_tensordxd(tensordxd_k);
   Kokkos::parallel_for("phonon_thermal_cond", Kokkos::RangePolicy<Kokkos::HostSpace::execution_space>(0, niss), [&] (int iis){
+
       auto tensorPrivate = scatter_tensordxd.access();
 
       int is = iss[iis];
@@ -78,10 +80,10 @@ void PhononThermalConductivity::calcFromPopulation(VectorBTE &n) {
 
       auto rots = bandStructure.getRotationsStar(isIdx);
       for (const Eigen::Matrix3d &rot : rots) {
+
         auto vel = rot * velIrr;
 
-        for (int iCalc = 0; iCalc < statisticsSweep.getNumCalculations();
-             iCalc++) {
+        for (int iCalc = 0; iCalc < statisticsSweep.getNumCalculations(); iCalc++) {
 
           Eigen::Vector3d nRot;
           for (int i : {0, 1, 2}) {
@@ -223,34 +225,68 @@ void PhononThermalConductivity::calcVariational(VectorBTE &af, VectorBTE &f,
   tensordxd = 2 * y2 - y1;
 }
 
+// TODO this should be commented better to make it more understandable -- Jenny
 void PhononThermalConductivity::calcFromRelaxons(
     Context &context, StatisticsSweep &statisticsSweep,
     ParallelMatrix<double> &eigenvectors, PhScatteringMatrix &scatteringMatrix,
     const Eigen::VectorXd &eigenvalues) {
 
+  // Comments are Jenny attempting to trace a function written by Andrea
+  // See Cepellotti 2016 PRX about relaxons
+  // This function calculates the relaxon population delta n
+  // defined in that paper, and then supplies it to the thermal conductivity
+  // calculator.
+  //
+  // Here,
+  // alpha = relaxons eigenvalue index
+  // iMat1 = phonon state index
+
+  int numEigenvalues = eigenvalues.size();
   auto particle = bandStructure.getParticle();
 
-  int iCalc = 0;
+  int iCalc = 0; // relaxons only allows one calc in memory
   double temp = statisticsSweep.getCalcStatistics(iCalc).temperature;
   double chemPot = statisticsSweep.getCalcStatistics(iCalc).chemicalPotential;
-
   VectorBTE population(statisticsSweep, bandStructure, 3);
 
+  // if we only calculated some eigenvalues,
+  // we should not include any alpha
+  // values past that -- scalapack required the memory in eigenvectors to be allocated,
+  // however, for alpha>numEigenvalues, it contains zeros or nonsense.
+  // we also need to discard any negative states
+  std::vector<std::tuple<int, int>> allLocalStates = eigenvectors.getAllLocalStates();
+  std::vector<std::tuple<int, int>> localStates;
+  for(auto state : allLocalStates) {
+    int alpha = std::get<1>(state);
+    if (eigenvalues(alpha) <= 0. || alpha >= numEigenvalues) {
+      continue;
+    }
+    localStates.push_back(state);
+  }
+  int nlocalStates = localStates.size();
+
+  // now, use these states to calcuate the populations
+  // first, we calculate the relaxon populations f_alpha
   if (context.getUseSymmetries()) {
 
-    Eigen::VectorXd relPopulation(eigenvalues.size());
-    relPopulation.setZero();
+    // relaxons population f_alpha
+    Eigen::VectorXd relaxonsPopulation(numEigenvalues);
+    relaxonsPopulation.setZero();
 
-    std::vector<std::tuple<int, int>> localStates = eigenvectors.getAllLocalStates();
-    int nlocalStates = localStates.size();
 #pragma omp parallel default(none)                                             \
-    shared(relPopulation, temp, chemPot, scatteringMatrix, eigenvectors,       \
+    shared(relaxonsPopulation, temp, chemPot, scatteringMatrix, eigenvectors,       \
            eigenvalues, particle, localStates, nlocalStates)
     {
-      Eigen::VectorXd relPopPrivate(eigenvalues.size());
-      relPopPrivate.setZero();
+      // each omp process needs its own copy
+      Eigen::VectorXd relaxonsPopPrivate(eigenvalues.size());
+      relaxonsPopPrivate.setZero();
+
 #pragma omp for nowait
       for(int ilocalState = 0; ilocalState < nlocalStates; ilocalState++){
+
+        // calculate related state indices (need to use SMatrix for this when sym present)
+        // scalapack required eigenvectors to be the same size as
+        // the SMatrix, so this indexing works for eigenvectors, too.
         std::tuple<int,int> tup0 = localStates[ilocalState];
         int iMat1 = std::get<0>(tup0);
         int alpha = std::get<1>(tup0);
@@ -259,30 +295,32 @@ void PhononThermalConductivity::calcFromRelaxons(
         CartIndex dimIdx = std::get<1>(tup1);
         StateIndex isIdx = bandStructure.bteToState(iBteIdx);
         int iDim = dimIdx.get();
-        //
+
         auto vel = bandStructure.getGroupVelocity(isIdx);
         double en = bandStructure.getEnergy(isIdx);
         double term = sqrt(particle.getPopPopPm1(en, temp, chemPot));
         double dndt = particle.getDndt(en, temp, chemPot);
+        // Not sure which equation this comes from in 2016 PRX,
+        // maybe should check 2020
         if (eigenvalues(alpha) > 0. && en > 0.) {
-          relPopPrivate(alpha) += dndt / term * vel(iDim) *
+          //  sum(alpha, i) dn/dT * (1/sqrt(n(n+1)))
+          //                        * v_i * theta_mu,alpha * tau_alpha
+          relaxonsPopPrivate(alpha) += dndt / term * vel(iDim) *
                                   eigenvectors(iMat1, alpha) /
                                   eigenvalues(alpha);
         }
       }
 #pragma omp critical
       for (int alpha = 0; alpha < eigenvalues.size(); alpha++) {
-        relPopulation(alpha) += relPopPrivate(alpha);
+        relaxonsPopulation(alpha) += relaxonsPopPrivate(alpha);
       }
     }
-    mpi->allReduceSum(&relPopulation);
+    mpi->allReduceSum(&relaxonsPopulation);
 
     // back rotate to phonon coordinates
 
-    localStates = eigenvectors.getAllLocalStates();
-    nlocalStates = localStates.size();
 #pragma omp parallel default(none)                                             \
-    shared(bandStructure, eigenvectors, relPopulation, population,             \
+    shared(bandStructure, eigenvectors, relaxonsPopulation, population,             \
            scatteringMatrix, iCalc, localStates, nlocalStates)
     {
       Eigen::MatrixXd popPrivate(3, bandStructure.irrStateIterator().size());
@@ -299,7 +337,7 @@ void PhononThermalConductivity::calcFromRelaxons(
         int iBte = iBteIndex.get();
         int iDim = dimIndex.get();
         popPrivate(iDim, iBte) +=
-            eigenvectors(iMat1, alpha) * relPopulation(alpha);
+            eigenvectors(iMat1, alpha) * relaxonsPopulation(alpha);
       }
 
 #pragma omp critical
@@ -313,20 +351,17 @@ void PhononThermalConductivity::calcFromRelaxons(
 
   } else { // case without symmetries ------------------------------------------
 
-    Eigen::MatrixXd relPopulation(eigenvalues.size(), 3);
-    relPopulation.setZero();
-    std::vector<std::tuple<int,int>> localStates = eigenvectors.getAllLocalStates();
-    int nlocalStates = localStates.size();
+    Eigen::MatrixXd relaxonsPopulation(eigenvalues.size(), 3);
+    relaxonsPopulation.setZero();
 #pragma omp parallel default(none)                                             \
-    shared(eigenvectors, eigenvalues, temp, chemPot, particle, relPopulation, localStates, nlocalStates)
+    shared(eigenvectors, eigenvalues, temp, chemPot, particle, relaxonsPopulation, localStates, nlocalStates)
     {
-      Eigen::MatrixXd relPopPrivate(eigenvalues.size(), 3);
-      relPopPrivate.setZero();
+      Eigen::MatrixXd relaxonsPopPrivate(eigenvalues.size(), 3);
+      relaxonsPopPrivate.setZero();
 #pragma omp for nowait
       for(int ilocalState = 0; ilocalState < nlocalStates; ilocalState++){
         std::tuple<int,int> tup0 = localStates[ilocalState];
         int is = std::get<0>(tup0);
-
         StateIndex isIdx(is);
         int alpha = std::get<1>(tup0);
         double en = bandStructure.getEnergy(isIdx);
@@ -335,7 +370,7 @@ void PhononThermalConductivity::calcFromRelaxons(
           double term = sqrt(particle.getPopPopPm1(en, temp, chemPot));
           double dndt = particle.getDndt(en, temp, chemPot);
           for (int i = 0; i < 3; i++) {
-            relPopPrivate(alpha, i) += dndt / term * vel(i) *
+            relaxonsPopPrivate(alpha, i) += dndt / term * vel(i) *
                                        eigenvectors(is, alpha) /
                                        eigenvalues(alpha);
           }
@@ -344,27 +379,26 @@ void PhononThermalConductivity::calcFromRelaxons(
 #pragma omp critical
       for (int alpha = 0; alpha < eigenvalues.size(); alpha++) {
         for (int i = 0; i < 3; i++) {
-          relPopulation(alpha, i) += relPopPrivate(alpha, i);
+          relaxonsPopulation(alpha, i) += relaxonsPopPrivate(alpha, i);
         }
       }
     }
-    mpi->allReduceSum(&relPopulation);
-    localStates = eigenvectors.getAllLocalStates();
-    nlocalStates = localStates.size();
+    mpi->allReduceSum(&relaxonsPopulation);
+
     // back rotate to phonon coordinates
 #pragma omp parallel default(none)                                             \
-    shared(eigenvectors, relPopulation, population, iCalc, localStates, nlocalStates)
+    shared(eigenvectors, relaxonsPopulation, population, iCalc, localStates, nlocalStates)
     {
       Eigen::MatrixXd popPrivate(3, bandStructure.getNumStates());
       popPrivate.setZero();
+
 #pragma omp for nowait
       for(int ilocalState = 0; ilocalState < nlocalStates; ilocalState++){
         std::tuple<int,int> tup0 = localStates[ilocalState];
         int is = std::get<0>(tup0);
         int alpha = std::get<1>(tup0);
         for (int i = 0; i < 3; i++) {
-          popPrivate(i, is) +=
-              eigenvectors(is, alpha) * relPopulation(alpha, i);
+          popPrivate(i, is) += eigenvectors(is, alpha) * relaxonsPopulation(alpha, i);
         }
       }
 #pragma omp critical
@@ -376,8 +410,8 @@ void PhononThermalConductivity::calcFromRelaxons(
     }
     mpi->allReduceSum(&population.data);
   }
-  // put back the rescaling factor
 
+  // put back the rescaling factor
   std::vector<int> iss = bandStructure.irrStateIterator();
   int niss = iss.size();
 #pragma omp parallel for default(none)                                         \
@@ -394,7 +428,7 @@ void PhononThermalConductivity::calcFromRelaxons(
       }
     }
   }
-
+  // now calculate the thermal conductivity using the relaxons population
   calcFromPopulation(population);
 }
 

--- a/src/observable/phonon_viscosity.cpp
+++ b/src/observable/phonon_viscosity.cpp
@@ -45,7 +45,7 @@ void PhononViscosity::calcRTA(VectorBTE &tau) {
 
   Kokkos::View<double*****, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> tensordxdxdxd_k(tensordxdxdxd.data(), numCalculations, dimensionality, dimensionality, dimensionality, dimensionality);
   Kokkos::Experimental::ScatterView<double*****, Kokkos::LayoutLeft, Kokkos::HostSpace> scatter_tensordxdxdxd(tensordxdxdxd_k);
-  Kokkos::parallel_for("electron_viscosity", Kokkos::RangePolicy<Kokkos::HostSpace::execution_space>(0, niss), [&] (int iis){
+  Kokkos::parallel_for("phonon_viscosity", Kokkos::RangePolicy<Kokkos::HostSpace::execution_space>(0, niss), [&] (int iis){
       auto tmpTensor = scatter_tensordxdxdxd.access();
       int is = iss[iis];
       auto isIdx = StateIndex(is);
@@ -115,21 +115,20 @@ void PhononViscosity::calcRTA(VectorBTE &tau) {
   mpi->allReduceSum(&tensordxdxdxd);
 }
 
-void PhononViscosity::calcFromRelaxons(Vector0 &vector0,
+void PhononViscosity::calcFromRelaxons(//Vector0 &vector0,
                                        Eigen::VectorXd &eigenvalues,
-                                       PhScatteringMatrix &sMatrix,
                                        ParallelMatrix<double> &eigenvectors) {
 
+  // to simplify, here I do everything considering there is a single
+  // temperature (due to memory constraints)
   if (numCalculations > 1) {
-    Error("Viscosity for relaxons only for 1 temperature");
+    Error("Developer error: Viscosity for relaxons only for 1 temperature.");
   }
 
   double volume = crystal.getVolumeUnitCell(dimensionality);
   int numStates = bandStructure.getNumStates();
+  int numRelaxons = eigenvalues.size();
   auto particle = bandStructure.getParticle();
-
-  // to simplify, here I do everything considering there is a single
-  // temperature (due to memory constraints)
 
   Eigen::VectorXd A(dimensionality);
   A.setZero();
@@ -139,6 +138,34 @@ void PhononViscosity::calcFromRelaxons(Vector0 &vector0,
   double temp = calcStat.temperature;
   double chemPot = calcStat.chemicalPotential;
 
+  // Code by Andrea, annotation by Jenny
+  // Here we are calculating Eq. 9 from the PRX Simoncelli 2020
+  //    mu_ijkl = (eta_ijkl + eta_ilkj)/2
+  // where
+  //   eta_ijkl =
+  //    sqrt(A_i A_j) \sum_(alpha > 0) w_i,alpha^j * w_k,alpha^l * tau_alpha
+  //
+  // For this, we will need three quantities:
+  //    A_i = specific momentum in direction i
+  //        = (1/kBT*vol) \sum_nu n_nu (n_nu+1) (hbar q_i)^2
+  //    w^j_i,alpha = velocity tensor
+  //        = 1/vol * \sum_nu phi_nu^i v_nu^j theta_nu^alpha
+  //    phi^i_nu = drift eigenvectors  (appendix eq A12)
+  //             = zero eigenvectors linked to momentum conservation
+  //             = sqrt(n(n+1)/kbT * A_i) * hbar * q_i
+  //
+  // And here the definitions are:
+  //    alpha = relaxons eigenlabel index
+  //    ijkl = cartesian direction indices
+  //    nu  = phonon mode index
+  //    n   = bose factor
+  //    phi = special zero eigenvectors linked to momentum conservation
+  //        = drift eigenvectors -- see appendix eq A12
+  //    q   = wavevector
+  //    theta = relaxons eigenvector
+  //    tau = relaxons eigenvalues/relaxation times
+
+  // calculate first A_i
   for (int is : bandStructure.parallelStateIterator()) {
     auto isIdx = StateIndex(is);
     auto en = bandStructure.getEnergy(isIdx);
@@ -151,6 +178,9 @@ void PhononViscosity::calcFromRelaxons(Vector0 &vector0,
   A /= temp * context.getQMesh().prod() * volume;
   mpi->allReduceSum(&A);
 
+  // then calculate the drift eigenvectors, phi (eq A12)
+  // NOTE: from Jenny -- doesn't plugging Ai into
+  // phi basically cancel out? Why compute both of these at all?
   VectorBTE driftEigenvector(statisticsSweep, bandStructure, 3);
   for (int is : bandStructure.parallelStateIterator()) {
     auto isIdx = StateIndex(is);
@@ -159,117 +189,114 @@ void PhononViscosity::calcFromRelaxons(Vector0 &vector0,
     auto q = bandStructure.getWavevector(isIdx);
     for (auto iDim : {0, 1, 2}) {
       if (A(iDim) != 0.) {
-        driftEigenvector(0, iDim, is) = q(iDim) * sqrt(boseP1 / temp / A(iDim));
+        driftEigenvector(0, iDim, is) = q(iDim) * sqrt(boseP1 / (temp * A(iDim)));
       }
     }
   }
   mpi->allReduceSum(&driftEigenvector.data);
 
+/* // Jenny's NOTE: Andrea wrote this here initially -- but it seems unused...
+  // also worth noting that the smatrix is absolutely trash by this point,
+  // scalapack has destroyed it in the diagonalization
   Eigen::MatrixXd D(3, 3);
   D.setZero();
   //    D = driftEigenvector * sMatrix.dot(driftEigenvector.transpose());
   VectorBTE tmp = sMatrix.dot(driftEigenvector);
   for (int is : bandStructure.parallelStateIterator()) {
     for (auto i : {0, 1, 2}) {
-      for (auto j : {0, 1, 2}) {
-        D(i, j) += driftEigenvector(0, i, is) * tmp(0, j, is);
+    for (auto j : {0, 1, 2}) {
+    D(i, j) += driftEigenvector(0, i, is) * tmp(0, j, is);
       }
     }
   }
   D /= volume * context.getQMesh().prod();
   mpi->allReduceSum(&D);
+*/
 
+  // calculate the first part of w^j_i,alpha
+  // Jenny's NOTE:  Why compute D8? it seems to never be used again...
+  // W^j_0,beta, the velocity tensor as in eq D8
+  // where vector0 is (eq A8 of PRX 2020), the Bose Einstein eigenvector:
+  //           theta_0^\nu= sqrt(n(n+1)/kbT * A_i) * hbar * q_i
+  // seems like wasted effort to calculate this though, as it is never used!
   Eigen::Tensor<double, 3> tmpDriftEigvecs(3, 3, numStates);
   tmpDriftEigvecs.setZero();
-  Eigen::MatrixXd W(3, 3);
-  W.setZero();
+  //Eigen::MatrixXd W(3, 3);
+  //W.setZero();
   for (int is : bandStructure.parallelStateIterator()) {
     auto isIdx = StateIndex(is);
     auto v = bandStructure.getGroupVelocity(isIdx);
     for (int i : {0, 1, 2}) {
       for (int j : {0, 1, 2}) {
         tmpDriftEigvecs(i, j, is) = driftEigenvector(0, j, is) * v(i);
-        W(i, j) += vector0(0, 0, is) * v(i) * driftEigenvector(0, j, is);
+        //W(i, j) += vector0(0, 0, is) * v(i) * driftEigenvector(0, j, is);
       }
     }
   }
-  W /= volume * context.getQMesh().prod();
-  mpi->allReduceSum(&W);
+  //W /= volume * context.getQMesh().prod();
+  //mpi->allReduceSum(&W);
   mpi->allReduceSum(&tmpDriftEigvecs);
 
+  // now we're calculating w
   Eigen::Tensor<double, 3> w(3, 3, numStates);
   w.setZero();
   for (auto i : {0, 1, 2}) {
     for (auto j : {0, 1, 2}) {
+      // drift eigenvectors * v -- only have phonon state indices
+      // and cartesian directions
       Eigen::VectorXd x(numStates);
       for (int is = 0; is < numStates; is++) {
         x(is) = tmpDriftEigvecs(i, j, is);
       }
 
-      // auto x2 = x.transpose() * eigenvectors;
-
-      std::vector<double> x2(numStates, 0.);
+      // w^j_i,alpha = sum_is1 phi*v*theta
+      std::vector<double> x2(numRelaxons, 0.);
       for (auto tup : eigenvectors.getAllLocalStates()) {
         auto is1 = std::get<0>(tup);
-        auto is2 = std::get<1>(tup);
-        x2[is2] += x(is1) * eigenvectors(is1, is2);
+        auto alpha = std::get<1>(tup);
+        if(alpha >= numRelaxons) continue; // wasn't calculated
+        x2[alpha] += x(is1) * eigenvectors(is1, alpha);
       }
       mpi->allReduceSum(&x2);
 
-      for (int is = 0; is < numStates; is++) {
-        w(i, j, is) = x2[is] / sqrt(volume) / sqrt(context.getQMesh().prod());
+      // normalize by 1/(Nq*Volume)
+      for (int ialpha = 0; ialpha < numRelaxons; ialpha++) {
+        w(i, j, ialpha) = x2[ialpha] / ( sqrt(volume) * sqrt(context.getQMesh().prod()) );
       }
-      // note: in Eq. 9 of PRX, w is normalized by V*N_q
+      // Andrea's note: in Eq. 9 of PRX, w is normalized by V*N_q
       // here however I normalize the eigenvectors differently:
       // \sum_state theta_s^2 = 1, instead of 1/VN_q \sum_state theta_s^2 = 1
     }
   }
 
-  // Eq. 9, Simoncelli PRX (2019)
+  // Eq. 9, Simoncelli PRX (2020)
   tensordxdxdxd.setZero();
-  std::vector<int> iss = bandStructure.parallelIrrStateIterator();
+  // eigenvectors and values may only be calculated up to numRelaxons, < numStates
+  std::vector<size_t> iss = mpi->divideWorkIter(numRelaxons);
   int niss = iss.size();
 
+// TODO why would we do this rather than a kokkos parallel for?
   Kokkos::View<double*****, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> tensordxdxdxd_k(tensordxdxdxd.data(), numCalculations, dimensionality, dimensionality, dimensionality, dimensionality);
   Kokkos::Experimental::ScatterView<double*****, Kokkos::LayoutLeft, Kokkos::HostSpace> scatter_tensordxdxdxd(tensordxdxdxd_k);
   Kokkos::parallel_for("electron_viscosity", Kokkos::RangePolicy<Kokkos::HostSpace::execution_space>(0, niss), [&] (int iis){
       auto tmpTensor = scatter_tensordxdxdxd.access();
-      int is = iss[iis];
-      if (eigenvalues(is) <= 0.) { // avoid division by zero
+      int ialpha = iss[iis];
+      if (eigenvalues(ialpha) <= 0.) { // avoid division by zero
         return;
       }
       for (int i = 0; i < dimensionality; i++) {
         for (int j = 0; j < dimensionality; j++) {
           for (int k = 0; k < dimensionality; k++) {
             for (int l = 0; l < dimensionality; l++) {
-            tmpTensor(iCalc, i, j, k, l) +=
-            0.5 *
-            (w(i, j, is) * w(k, l, is) + w(i, l, is) * w(k, j, is)) *
-            A(i) * A(k) / eigenvalues(is);
+            tmpTensor(iCalc, i, j, k, l) += 0.5 *
+            (w(i, j, ialpha) * w(k, l, ialpha) + w(i, l, ialpha) * w(k, j, ialpha)) *
+            A(i) * A(k) / eigenvalues(ialpha);
             }
           }
         }
       }
     });
   Kokkos::Experimental::contribute(tensordxdxdxd_k, scatter_tensordxdxdxd);
-  /*
-#pragma omp parallel default(none) shared(tensordxdxdxd,bandStructure,dimensionality,eigenvalues,w,A,iCalc)
-  {
-    Eigen::Tensor<double, 5> tmpTensor = tensordxdxdxd.constant(0.);
-#pragma omp for nowait
-    for (int is : bandStructure.parallelStateIterator()) {
-#pragma omp critical
-    for (int i = 0; i < dimensionality; i++) {
-      for (int j = 0; j < dimensionality; j++) {
-        for (int k = 0; k < dimensionality; k++) {
-          for (int l = 0; l < dimensionality; l++) {
-            tensordxdxdxd(iCalc, i, j, k, l) += tmpTensor(iCalc, i, j, k, l);
-          }
-        }
-      }
-    }
-  }
-  */
   mpi->allReduceSum(&tensordxdxdxd);
 }
 

--- a/src/observable/phonon_viscosity.h
+++ b/src/observable/phonon_viscosity.h
@@ -49,8 +49,7 @@ public:
    * @param eigenvectors: the eigenvectors of the scattering matrix above.
    */
    // previously used vector0: VectorBTE object with the energy-conserving eigenvector.
-  void calcFromRelaxons(//Vector0 &vector0,
-                        Eigen::VectorXd &eigenvalues,
+  void calcFromRelaxons(Eigen::VectorXd &eigenvalues,
                         ParallelMatrix<double> &eigenvectors);
 
 protected:

--- a/src/observable/phonon_viscosity.h
+++ b/src/observable/phonon_viscosity.h
@@ -44,14 +44,13 @@ public:
   void outputToJSON(const std::string& outFileName);
 
   /** Computes the viscosity from the scattering matrix eigenvectors.
-   * Following Simoncelli PRX 2020. Stores it internally.
-   * @param vector0: VectorBTE object with the energy-conserving eigenvector.
+   * Following Simoncelli PRX 2020.
    * @param relTimes: the VectorBTE object with relaxon relaxation times.
-   * @oaram sMatrix: the scattering matrix.
-   * @oaram eigenvectors: the eigenvectors of the scattering matrix above.
+   * @param eigenvectors: the eigenvectors of the scattering matrix above.
    */
-  void calcFromRelaxons(Vector0 &vector0, Eigen::VectorXd &eigenvalues,
-                        PhScatteringMatrix &sMatrix,
+   // previously used vector0: VectorBTE object with the energy-conserving eigenvector.
+  void calcFromRelaxons(//Vector0 &vector0,
+                        Eigen::VectorXd &eigenvalues,
                         ParallelMatrix<double> &eigenvectors);
 
 protected:


### PR DESCRIPTION
### Summary:

This PR contains several updates to the relaxons solver. 
The code is now as much as 1-2 orders of magnitude faster on the scattering matrix diagonalization due to improvements in the ScaLAPACK calls. 

The key changes are:
* Full matrix diagonalization call was swapped from pdsyev->pdsyevd
*  Matrix distribution block size is now more reasonable -- before it was too "block" and not enough "cyclic". Block sizes around ~10-100 seem to provide about a factor of 5x speedup from the old setup. 
* The option to only compute transport using a certain number of relaxons states has been added with the input variable "numRelaxonsEigenvalues". This can also boost performance when testing calculations. 
* Better print statements around the relaxons solver execution 