### PR TITLE
Minor Bugfix + more robust ScaLAPACK block size choice

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,6 +59,6 @@ export LIBRARY_PATH=/path/to/libgfortran/
 If using homebrew installed gcc, you might need to add the cellar copy rather than the
 one located with gcc:
 ```
-export LIBRARY_PATH=/usr/local/Cellar/gcc/9.3.0_1/lib/gcc/9/
+export LIBRARY_PATH=$LIBRARY_PATH:/opt/homebrew/Cellar/gcc/12.2.0/lib/gcc/12/
 ```
 

--- a/src/bte/scattering.cpp
+++ b/src/bte/scattering.cpp
@@ -139,7 +139,7 @@ void ScatteringMatrix::setup() {
       // only come up for very tiny cases where speed is not an issue,
       // therefore, we default to 4 blocks if this happens.
       // Seems like this is maybe a bug in scalapack?
-      if(nBlocks < 4) nBlocks = 4;
+      if(nBlocks < int(sqrt(mpi->getSize()))) nBlocks = int(sqrt(mpi->getSize())) * 2;
 
       theMatrix = ParallelMatrix<double>(matSize, matSize, 0, 0, nBlocks, nBlocks);
 

--- a/src/bte/scattering.cpp
+++ b/src/bte/scattering.cpp
@@ -139,7 +139,7 @@ void ScatteringMatrix::setup() {
       // only come up for very tiny cases where speed is not an issue,
       // therefore, we default to 4 blocks if this happens.
       // Seems like this is maybe a bug in scalapack?
-      if(nBlocks < int(sqrt(mpi->getSize()))) nBlocks = int(sqrt(mpi->getSize())) * 2;
+      if(nBlocks <= int(sqrt(mpi->getSize()))) nBlocks = int(sqrt(mpi->getSize())) * 2;
 
       theMatrix = ParallelMatrix<double>(matSize, matSize, 0, 0, nBlocks, nBlocks);
 

--- a/src/statistics_sweep.cpp
+++ b/src/statistics_sweep.cpp
@@ -305,11 +305,16 @@ StatisticsSweep::findChemicalPotentialFromDoping(const double &doping,
     }
   }
 
-  // I choose the following (generous) boundaries
-  double aX = *min_element(energies.begin(), energies.end()) - 1.;
-  double bX = *max_element(energies.begin(), energies.end()) + 1.;
-  // note: +-1 Ry = 13 eV should work for most dopings and temperatures,
-  // even in corner cases
+  double aX = 0; double bX = 0;
+  // if this is a weird case where this processor has zero
+  // states, the below lines will cause a seg fault
+  if(energies.size() > 0) {
+    // I choose the following (generous) boundaries
+    aX = *min_element(energies.begin(), energies.end()) - 1.;
+    bX = *max_element(energies.begin(), energies.end()) + 1.;
+    // note: +-1 Ry = 13 eV should work for most dopings and temperatures,
+    // even in corner cases
+  }
 
   // if energies are distributed, each process needs to have the global
   // minimum and maximum of the energies


### PR DESCRIPTION
### Two edge-case bug fixes are included in this PR: 
1) In cases where very many MPI processes were used with very few electronic states, a process could occasionally come up with zero electronic states, resulting in a seg fault during the determination of the chemical potential. 
2) In cases with very few states and the full scattering matrix used, ScaLAPACK would sometimes throw an internal error because block sizes were too small. Unfortunately, this error doesn't return an error code and so it's not possible to detect and kill the run, but it does result in a slightly incorrect value. Ideally this fix ends that issue, however, if an error referencing PDORMTR error is seen during the scattering matrix diagonalization, the results should never be trusted and the user should contact a developer. 