### PR TITLE
Set matrix symmetrization default to false

### DIFF
--- a/doc/sphinx/source/inputFiles.rst
+++ b/doc/sphinx/source/inputFiles.rst
@@ -974,13 +974,13 @@ scatteringMatrixInMemory
 symmetrizeMatrix
 ^^^^^^^^^^^^^^^^
 
-* **Description:** If true, we enforce the symmetrix property of the scattering matrix A by doing A=(A^T+A)/2, where the transpose operation is made with respect to the wavevector indices. This operation increases the stability of the variational and relaxon solvers. Set this variable to false to increase the speed of the simulation in exchange for additional numerical noise.
+* **Description:** If true, we enforce the symmetrix property of the scattering matrix A by doing A=(A^T+A)/2, where the transpose operation is made with respect to the wavevector indices. This operation increases the stability of the variational and relaxon solvers, but is computationally expensive in large system sizes. If you find your calculation has many negative relaxons eigenvalues, you might want to turn this on. This may also be favorable for your final production calculations.
 
 * **Format:** *bool*
 
 * **Required:** no
 
-* **Default:** `true`
+* **Default:** `false`
 
 
 .. _numRelaxonsEigenvalues:

--- a/example/Silicon-el/electronWannierTransport.in
+++ b/example/Silicon-el/electronWannierTransport.in
@@ -12,6 +12,7 @@ smearingMethod = "gaussian"
 smearingWidth = 0.5 eV
 windowType = "population"
 
+# for a production relaxons run, use this -- otherwise, false
 symmetrizeMatrix = true
 scatteringMatrixInMemory=true
 solverBTE = ["iterative","variational","relaxons"]

--- a/example/Silicon-el/electronWannierTransport.in
+++ b/example/Silicon-el/electronWannierTransport.in
@@ -12,5 +12,6 @@ smearingMethod = "gaussian"
 smearingWidth = 0.5 eV
 windowType = "population"
 
+symmetrizeMatrix = true
 scatteringMatrixInMemory=true
 solverBTE = ["iterative","variational","relaxons"]

--- a/example/Silicon-ph/phononTransport.in
+++ b/example/Silicon-ph/phononTransport.in
@@ -11,6 +11,7 @@ smearingMethod = "gaussian"
 smearingWidth = 10. cmm1
 
 solverBTE = ["iterative", "variational","relaxons"]
+symmetrizeMatrix = true
 scatteringMatrixInMemory = true
 
 boundaryLength = 1. mum

--- a/example/Silicon-ph/phononTransport.in
+++ b/example/Silicon-ph/phononTransport.in
@@ -11,6 +11,7 @@ smearingMethod = "gaussian"
 smearingWidth = 10. cmm1
 
 solverBTE = ["iterative", "variational","relaxons"]
+ # for a production relaxons run, use this -- otherwise, false
 symmetrizeMatrix = true
 scatteringMatrixInMemory = true
 

--- a/src/bte/scattering.cpp
+++ b/src/bte/scattering.cpp
@@ -139,7 +139,7 @@ void ScatteringMatrix::setup() {
       // only come up for very tiny cases where speed is not an issue,
       // therefore, we default to 4 blocks if this happens.
       // Seems like this is maybe a bug in scalapack?
-      if(nBlocks < 4) nBlocks = 4;
+      if(nBlocks < 10) nBlocks = 10;
 
       theMatrix = ParallelMatrix<double>(matSize, matSize, 0, 0, nBlocks, nBlocks);
 

--- a/src/context.h
+++ b/src/context.h
@@ -117,7 +117,7 @@ class Context {
   // currently only support parallelization of the qe2Phoebe app
 
   // if true, enforce the symmetrization of the scattering matrix
-  bool symmetrizeMatrix = true;
+  bool symmetrizeMatrix = false;
 
   // number of eigenvalues to use the in the relaxons solver
   int numRelaxonsEigenvalues = 0;


### PR DESCRIPTION
In the current version of Phoebe, the scattering matrix is symmetrized before the relaxons solver is run as a default. In many cases, this is unnecessary, and for large matrices, is slower than the diagonalization of the matrix -- therefore, to avoid users running into this, we set the [symmetrizeMatrix](https://phoebe.readthedocs.io/en/develop/inputFiles.html#symmetrizematrix) input option to false by default (and make a a further note about this in the input docs). 

This is because, of course, dong A + A^T/ 2 for a distributed matrix is not really a sensible operation. We leave the option there, to be used for production runs. Tests show that in copper, the difference between the solve with and without matrix symmetrization is < 1 W/m/K. 