### PR TITLE
El-ph interpolation speedup using kokkos-kernels

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/kokkos"]
 	path = lib/kokkos
 	url = https://github.com/kokkos/kokkos.git
+[submodule "lib/kokkos-kernels"]
+	path = lib/kokkos-kernels
+	url = https://github.com/kokkos/kokkos-kernels

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,9 @@ set_target_properties(runTests PROPERTIES EXCLUDE_FROM_ALL TRUE)
 add_dependencies(phoebe spglib_dep pugixml_dep eigen_dep)
 add_dependencies(runTests spglib_dep pugixml_dep eigen_dep)
 
-target_link_libraries(phoebe symspg pugixml kokkos nlohmann_json::nlohmann_json)
+target_link_libraries(phoebe symspg pugixml kokkos Kokkos::kokkoskernels nlohmann_json::nlohmann_json)
 enable_testing()
-target_link_libraries(runTests symspg pugixml gtest_main kokkos nlohmann_json::nlohmann_json)
+target_link_libraries(runTests symspg pugixml gtest_main kokkos Kokkos::kokkoskernels nlohmann_json::nlohmann_json)
 
 gtest_discover_tests(
     runTests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,17 @@ option(OMP_AVAIL "Build with OMP" ON)
 option(HDF5_AVAIL "Build with HDF5" ON)
 option(HDF5_SERIAL "Force build to accomodate serial only HDF5, but still use MPI" OFF)
 option(BUILD_DOC "Build documentation" ON)
+
+############## KOKKOS #################
 if(OMP_AVAIL)
   option(Kokkos_ENABLE_OPENMP "Use kokkos with omp" ON)
 else()
   option(Kokkos_ENABLE_OPENMP "Use kokkos with omp" OFF)
   option(Kokkos_ENABLE_SERIAL "Use kokkos in serial" ON)
 endif()
+set(KokkosKernels_ADD_DEFAULT_ETI OFF CACHE BOOL "faster build")
+set(KokkosKernels_ENABLED_COMPONENTS BLAS CACHE STRING "faster build")
+
 ############### SOURCE ###############
 
 FILE(GLOB_RECURSE SOURCE_FILES src src/*.cpp)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(lib/kokkos)
+add_subdirectory(lib/kokkos-kernels)
 
 include(ExternalProject)
 include(FetchContent)

--- a/src/algebra/PMatrix.cpp
+++ b/src/algebra/PMatrix.cpp
@@ -154,10 +154,14 @@ ParallelMatrix<double>::diagonalize() {
      mpi->time();
   }
 
+  Kokkos::Profiling::pushRegion("pdsyevd");
+
   // call the function to now diagonalize
   pdsyevd_(&jobz, &uplo, &numRows_, mat, &ia, &ja, &descMat_[0], eigenvalues,
           eigenvectors.mat, &ia, &ja, &eigenvectors.descMat_[0],
           work, &lwork, iwork, &liwork, &info);
+
+  Kokkos::Profiling::popRegion();
 
   if(mpi->mpiHead()) {
      std::cout << "Matrix diagonalization completed." << std::endl;
@@ -313,10 +317,15 @@ std::tuple<std::vector<double>, ParallelMatrix<double>>
   allocate(work, 1);
   allocate(iwork, 1);
 
+
+  Kokkos::Profiling::pushRegion("pdsyevr");
+
   pdsyevr_(&jobz, &range, &uplo,  &numRows_, mat, &ia, &ja, &descMat_[0],
         &vl, &vu, &il, &iu, &m, &nz, eigenvalues,
         eigenvectors.mat, &iz, &jz, &eigenvectors.descMat_[0],
         work, &lwork, iwork, &liwork, &info);
+
+  Kokkos::Profiling::popRegion();
 
   lwork=int(work[0]);
   delete[] work;

--- a/src/apps/electron_wannier_transport_app.cpp
+++ b/src/apps/electron_wannier_transport_app.cpp
@@ -12,6 +12,7 @@
 
 void ElectronWannierTransportApp::run(Context &context) {
 
+  Kokkos::Profiling::pushRegion("ETapp.parseHamiltonians");
   auto t2 = Parser::parsePhHarmonic(context);
   auto crystal = std::get<0>(t2);
   auto phononH0 = std::get<1>(t2);
@@ -19,23 +20,28 @@ void ElectronWannierTransportApp::run(Context &context) {
   auto t1 = Parser::parseElHarmonicWannier(context, &crystal);
   auto crystalEl = std::get<0>(t1);
   auto electronH0 = std::get<1>(t1);
+  Kokkos::Profiling::popRegion();
 
   // load the elph coupling
   // Note: this file contains the number of electrons
   // which is needed to understand where to place the fermi level
+  Kokkos::Profiling::pushRegion("ETapp.parseInteraction");
   InteractionElPhWan couplingElPh(crystal);
   if (std::isnan(context.getConstantRelaxationTime())) {
     couplingElPh = InteractionElPhWan::parse(context, crystal, &phononH0);
   }
+  Kokkos::Profiling::popRegion();
 
   // compute the band structure on the fine grid
   if (mpi->mpiHead()) {
     std::cout << "\nComputing electronic band structure." << std::endl;
   }
+  Kokkos::Profiling::pushRegion("ETapp.setupElBandstructure");
   Points fullPoints(crystal, context.getKMesh());
   auto t3 = ActiveBandStructure::builder(context, electronH0, fullPoints);
   auto bandStructure = std::get<0>(t3);
   auto statisticsSweep = std::get<1>(t3);
+  Kokkos::Profiling::popRegion();
 
   // print some info about how window and symmetries have reduced things
   if (mpi->mpiHead()) {
@@ -61,10 +67,12 @@ void ElectronWannierTransportApp::run(Context &context) {
   //  StatisticsSweep statisticsSweep(context, &bandStructure);
 
   // build/initialize the scattering matrix and the smearing
+  Kokkos::Profiling::pushRegion("ETapp.setupScatteringMatrix");
   ElScatteringMatrix scatteringMatrix(context, statisticsSweep, bandStructure,
                                       bandStructure, phononH0, &couplingElPh);
   scatteringMatrix.setup();
   scatteringMatrix.outputToJSON("rta_el_relaxation_times.json");
+  Kokkos::Profiling::popRegion();
 
   // solve the BTE at the relaxation time approximation level
   // we always do this, as it's the cheapest solver and is required to know
@@ -78,6 +86,8 @@ void ElectronWannierTransportApp::run(Context &context) {
   // compute the phonon populations in the relaxation time approximation.
   // Note: this is the total phonon population n (n != f(1+f) Delta n)
 
+  Kokkos::Profiling::pushRegion("ETapp.computeRTATransport");
+
   BulkEDrift driftE(statisticsSweep, bandStructure, 3);
   BulkTDrift driftT(statisticsSweep, bandStructure, 3);
   VectorBTE relaxationTimes = scatteringMatrix.getSingleModeTimes();
@@ -85,22 +95,19 @@ void ElectronWannierTransportApp::run(Context &context) {
   VectorBTE nTRTA = -driftT * relaxationTimes;
 
   // compute the electrical conductivity
-  OnsagerCoefficients transportCoefficients(statisticsSweep, crystal,
-                                            bandStructure, context);
+  OnsagerCoefficients transportCoefficients(statisticsSweep, crystal, bandStructure, context);
   transportCoefficients.calcFromPopulation(nERTA, nTRTA);
   transportCoefficients.print();
   transportCoefficients.outputToJSON("rta_onsager_coefficients.json");
 
   // compute the Wigner transport coefficients
-  WignerElCoefficients wignerCoefficients(
-      statisticsSweep, crystal, bandStructure, context, relaxationTimes);
+  WignerElCoefficients wignerCoefficients(statisticsSweep, crystal, bandStructure, context, relaxationTimes);
   wignerCoefficients.calcFromPopulation(nERTA, nTRTA);
   wignerCoefficients.print();
   wignerCoefficients.outputToJSON("rta_wigner_coefficients.json");
 
   // compute the electron viscosity
-  ElectronViscosity elViscosity(context, statisticsSweep, crystal,
-                                bandStructure);
+  ElectronViscosity elViscosity(context, statisticsSweep, crystal, bandStructure);
   elViscosity.calcRTA(relaxationTimes);
   elViscosity.print();
   elViscosity.outputToJSON("rta_electron_viscosity.json");
@@ -119,8 +126,12 @@ void ElectronWannierTransportApp::run(Context &context) {
     return; // if we used the constant RTA, we can't solve the BTE exactly
   }
 
+  Kokkos::Profiling::popRegion();
+
   //---------------------------------------------------------------------------
   // start section on exact BTE solvers
+
+  Kokkos::Profiling::pushRegion("ET.exactBTESolvers");
 
   std::vector<std::string> solverBTE = context.getSolverBTE();
 
@@ -182,6 +193,9 @@ void ElectronWannierTransportApp::run(Context &context) {
   }
 
   if (doRelaxons) {
+
+    Kokkos::Profiling::pushRegion("ETapp.relaxonsTransport");
+
     if (mpi->mpiHead()) {
       std::cout << "Starting relaxons BTE solver" << std::endl;
     }
@@ -210,7 +224,9 @@ void ElectronWannierTransportApp::run(Context &context) {
       std::cout << "Finished relaxons BTE solver\n\n";
       std::cout << std::string(80, '-') << "\n" << std::endl;
     }
+    Kokkos::Profiling::popRegion();
   }
+  Kokkos::Profiling::popRegion();
 }
 
 void ElectronWannierTransportApp::checkRequirements(Context &context) {

--- a/src/bands/active_bandstructure.cpp
+++ b/src/bands/active_bandstructure.cpp
@@ -123,11 +123,12 @@ ActiveBandStructure::ActiveBandStructure(const Points &points_,
         size_t ik = iks[start_iik+iik];
         Point point = points.getPoint(ik);
 
-
         for(int i = 0; i < numBands; i++){
           energies(i) = energies_h(iik,i);
-          for(int j = 0; j < numBands; j++){
-            eigenvectors(j,i) = eigenvectors_h(iik,j,i);
+          if (withEigenvectors) {
+            for(int j = 0; j < numBands; j++){
+              eigenvectors(j,i) = eigenvectors_h(iik,j,i);
+            }
           }
         }
 
@@ -145,7 +146,7 @@ ActiveBandStructure::ActiveBandStructure(const Points &points_,
     // the same again, but for velocities
     // TODO: I think this also returns the energies and velocities above, so we could avoid
     // the above calculation entirely (12.5% potential speedup)
-    Kokkos::Profiling::pushRegion("velocity loop");
+    Kokkos::Profiling::pushRegion("bandstructure velocity loop");
 
     int approx_batch_size = h0->estimateBatchSize(true);
 
@@ -442,6 +443,9 @@ void ActiveBandStructure::buildIndices() {
 }
 
 void ActiveBandStructure::buildSymmetries() {
+
+  Kokkos::Profiling::pushRegion("ABS.buildSymmetries");
+
   // ------------------
   // things to use in presence of symmetries
   {
@@ -477,6 +481,7 @@ void ActiveBandStructure::buildSymmetries() {
     }
     ikOld = ik;
   }
+  Kokkos::Profiling::popRegion();
 }
 
 std::tuple<ActiveBandStructure, StatisticsSweep>
@@ -497,6 +502,7 @@ ActiveBandStructure::builder(Context &context, HarmonicHamiltonian &h0,
 
     StatisticsSweep s = activeBandStructure.buildAsPostprocessing(
         context, points_, h0, withEigenvectors, withVelocities);
+
     return std::make_tuple(activeBandStructure, s);
 
   }
@@ -546,9 +552,9 @@ void ActiveBandStructure::buildOnTheFly(Window &window, Points points_,
   std::vector<int> filteredThreadPoints;
   std::vector<std::vector<int>> filteredThreadBands;
 
-  std::vector<size_t> pointsIter = mpi->divideWorkIter(points_.getNumPoints()); 
+  std::vector<size_t> pointsIter = mpi->divideWorkIter(points_.getNumPoints());
   #pragma omp for nowait schedule(static)
-  for (size_t iik = 0; iik < pointsIter.size(); iik++) { 
+  for (size_t iik = 0; iik < pointsIter.size(); iik++) {
 
     int ik = pointsIter[iik];
 

--- a/src/bte/helper_el_scattering.cpp
+++ b/src/bte/helper_el_scattering.cpp
@@ -20,6 +20,7 @@ HelperElScattering::HelperElScattering(BaseBandStructure &innerBandStructure_,
   // 3 - the mesh is complete (if q1 and q2 are only around 0, q3 might be
   //     at the border)
 
+  Kokkos::Profiling::pushRegion("HelperElScattering");
 
   auto t1 = outerBandStructure.getPoints().getMesh();
 //  auto mesh = std::get<0>(t1);
@@ -216,6 +217,7 @@ HelperElScattering::HelperElScattering(BaseBandStructure &innerBandStructure_,
       mappedPolarData.insert({alliq3s[iiq3], allPolarData.col(iiq3)});
     }
   }
+  Kokkos::Profiling::popRegion();
 }
 
 // auto [eigenValues3Minus, nb3Minus, eigenVectors3Minus, v3Minus, bose3]

--- a/src/interaction/interaction_elph.cpp
+++ b/src/interaction/interaction_elph.cpp
@@ -157,6 +157,8 @@ Eigen::VectorXcd InteractionElPhWan::polarCorrectionPart1Static(
     const Eigen::MatrixXd &atomicPositions, const Eigen::Vector3i &qCoarseMesh) {
   // doi:10.1103/physRevLett.115.176401, Eq. 4, is implemented here
 
+  Kokkos::Profiling::pushRegion("polarCorrectionPart1Static");
+
   auto numAtoms = int(atomicPositions.rows());
 
   // auxiliary terms
@@ -199,6 +201,7 @@ Eigen::VectorXcd InteractionElPhWan::polarCorrectionPart1Static(
       }
     }
   }
+  Kokkos::Profiling::popRegion();
   return x;
 }
 
@@ -487,6 +490,7 @@ int InteractionElPhWan::estimateNumBatches(const int &nk2, const int &nb1) {
 }
 
 void InteractionElPhWan::cacheElPh(const Eigen::MatrixXcd &eigvec1, const Eigen::Vector3d &k1C) {
+
   Kokkos::Profiling::pushRegion("cacheElPh");
   //  int numWannier = numElBands;
   auto nb1 = int(eigvec1.cols());
@@ -537,6 +541,7 @@ void InteractionElPhWan::cacheElPh(const Eigen::MatrixXcd &eigvec1, const Eigen:
       poolK1C = k1C;
       poolEigvec1 = eigvec1;
     }
+    // broadcast to other processes on this pool
     mpi->bcast(&poolK1C, mpi->intraPoolComm, iPool);
     mpi->bcast(&poolEigvec1, mpi->intraPoolComm, iPool);
 
@@ -544,8 +549,7 @@ void InteractionElPhWan::cacheElPh(const Eigen::MatrixXcd &eigvec1, const Eigen:
     ComplexView2D eigvec1_k("ev1", poolNb1, numElBands);
     DoubleView1D poolK1C_k("k", 3);
     {
-      HostComplexView2D eigvec1_h((Kokkos::complex<double> *) poolEigvec1.data(),
-                                  poolNb1, numElBands);
+      HostComplexView2D eigvec1_h((Kokkos::complex<double> *) poolEigvec1.data(), poolNb1, numElBands);
       HostDoubleView1D poolK1C_h(poolK1C.data(), 3);
       Kokkos::deep_copy(eigvec1_k, eigvec1_h);
       Kokkos::deep_copy(poolK1C_k, poolK1C_h);
@@ -565,10 +569,10 @@ void InteractionElPhWan::cacheElPh(const Eigen::MatrixXcd &eigvec1, const Eigen:
           for (int j = 0; j < 3; j++) {
             arg += poolK1C_k(j) * elBravaisVectors_k(irE, j);
           }
-          phases_k(irE) =
-              exp(complexI * arg) / elBravaisVectorsDegeneracies_k(irE);
+          phases_k(irE) = exp(complexI * arg) / elBravaisVectorsDegeneracies_k(irE);
         });
-   Kokkos::fence();
+    Kokkos::fence();
+    Kokkos::Profiling::popRegion();
 
     // now we complete the Fourier transform
     // We have to write two codes: one for when the GPU runs on CUDA,
@@ -626,8 +630,7 @@ void InteractionElPhWan::cacheElPh(const Eigen::MatrixXcd &eigvec1, const Eigen:
     // elPhCached. Otherwise, we need to do an MPI reduction
 
     if (pool_size == 1) {
-      Kokkos::realloc(elPhCached, numPhBravaisVectors, numPhBands, poolNb1,
-                      numElBands);
+      Kokkos::realloc(elPhCached, numPhBravaisVectors, numPhBands, poolNb1, numElBands);
 
       Kokkos::parallel_for(
           "elPhCached",
@@ -645,8 +648,7 @@ void InteractionElPhWan::cacheElPh(const Eigen::MatrixXcd &eigvec1, const Eigen:
     } else {
 
       ComplexView4D poolElPhCached_k(Kokkos::ViewAllocateWithoutInitializing("poolElPhCached"),
-                                   numPhBravaisVectors, numPhBands, poolNb1,
-                                   numElBands);
+                                   numPhBravaisVectors, numPhBands, poolNb1, numElBands);
 
       Kokkos::parallel_for(
           "elPhCached",
@@ -663,7 +665,6 @@ void InteractionElPhWan::cacheElPh(const Eigen::MatrixXcd &eigvec1, const Eigen:
       // note: we do the reduction after the rotation, so that the tensor
       // may be a little smaller when windows are applied (nb1<numWannier)
 
-
       // do a mpi->allReduce across the pool
       //mpi->allReduceSum(&poolElPhCached_h, mpi->intraPoolComm);
 
@@ -677,14 +678,16 @@ void InteractionElPhWan::cacheElPh(const Eigen::MatrixXcd &eigvec1, const Eigen:
 
 #ifdef MPI_AVAIL
       // start reduction for current iteration
-      Kokkos::Profiling::pushRegion("call MPI_Ireduce");
+      Kokkos::Profiling::pushRegion("call MPI_reduce");
       // previously, we had tried non-blocking collectives here.
       // However, this resulted in some segfaults, so we fell back to standard reduce.
       if (pool_rank == iPool) {
+        //MPI_Ireduce(MPI_IN_PLACE, poolElPhCached_h.data(), poolElPhCached_h.size(), MPI_COMPLEX16, MPI_SUM, iPool, mpi->getComm(mpi->intraPoolComm), &mpi_requests[iPool]);
         MPI_Reduce(MPI_IN_PLACE, poolElPhCached_h.data(), poolElPhCached_h.size(), MPI_COMPLEX16, MPI_SUM, iPool, mpi->getComm(mpi->intraPoolComm)); //, &mpi_requests[iPool]);
       }
       else{
         MPI_Reduce(poolElPhCached_h.data(), poolElPhCached_h.data(), poolElPhCached_h.size(), MPI_COMPLEX16, MPI_SUM, iPool, mpi->getComm(mpi->intraPoolComm)); //, &mpi_requests[iPool]);
+        //MPI_Ireduce(poolElPhCached_h.data(), poolElPhCached_h.data(), poolElPhCached_h.size(), MPI_COMPLEX16, MPI_SUM, iPool, mpi->getComm(mpi->intraPoolComm), &mpi_requests[iPool]);
       }
       Kokkos::Profiling::popRegion();
 #endif

--- a/src/observable/electron_viscosity.cpp
+++ b/src/observable/electron_viscosity.cpp
@@ -29,6 +29,8 @@ ElectronViscosity &ElectronViscosity::operator=(const ElectronViscosity &that) {
   Observable::operator=(that);
   if (this != &that) {
     bandStructure = that.bandStructure;
+
+  Kokkos::Profiling::pushRegion("HelperElScattering");
   }
   return *this;
 }
@@ -250,6 +252,7 @@ void ElectronViscosity::calcFromRelaxons(Eigen::VectorXd &eigenvalues,
     }
   }
   mpi->allReduceSum(&tensordxdxdxd);
+  Kokkos::Profiling::popRegion();
 }
 
 void ElectronViscosity::print() {

--- a/src/observable/onsager.cpp
+++ b/src/observable/onsager.cpp
@@ -153,6 +153,9 @@ void OnsagerCoefficients::calcFromSymmetricPopulation(VectorBTE &nE, VectorBTE &
 }
 
 void OnsagerCoefficients::calcFromPopulation(VectorBTE &nE, VectorBTE &nT) {
+
+  Kokkos::Profiling::pushRegion("calcOnsagerFromPopulation");
+
   double norm = spinFactor / context.getKMesh().prod() /
                 crystal.getVolumeUnitCell(dimensionality);
   LEE.setZero();
@@ -315,14 +318,16 @@ void OnsagerCoefficients::calcTransportCoefficients() {
       }
     }
   }
+  Kokkos::Profiling::popRegion();
 }
 
 void OnsagerCoefficients::calcFromRelaxons(
     Eigen::VectorXd &eigenvalues, ParallelMatrix<double> &eigenvectors,
     ElScatteringMatrix &scatteringMatrix) {
 
-  int numEigenvalues = eigenvalues.size();
+  Kokkos::Profiling::pushRegion("calcFromRelaxons");
 
+  int numEigenvalues = eigenvalues.size();
   int iCalc = 0;
   double chemPot = statisticsSweep.getCalcStatistics(iCalc).chemicalPotential;
   double temp = statisticsSweep.getCalcStatistics(iCalc).temperature;
@@ -429,6 +434,7 @@ void OnsagerCoefficients::calcFromRelaxons(
     mpi->allReduceSum(&nE.data);
     mpi->allReduceSum(&nT.data);
   }
+  Kokkos::Profiling::popRegion();
   calcFromSymmetricPopulation(nE, nT);
 }
 

--- a/src/parser/ifc3_parser.cpp
+++ b/src/parser/ifc3_parser.cpp
@@ -118,6 +118,8 @@ reorderDynamicalMatrix(
         &ifc3Tensor,
     const std::vector<int> &cellMap) {
 
+  Kokkos::Profiling::pushRegion("reorderDynamicalMatrix");
+
   int numAtoms = crystal.getNumAtoms();
   Eigen::MatrixXd atomicPositions = crystal.getAtomicPositions();
   int nr1Big = qCoarseGrid(0) * 2;
@@ -370,15 +372,17 @@ reorderDynamicalMatrix(
     }// close nb loop
   }  // close na loop
 
+  Kokkos::Profiling::popRegion();
   return std::make_tuple(bravaisVectors, weights, bravaisVectors, weights);
 }
 
 Interaction3Ph IFC3Parser::parseFromPhono3py(Context &context,
                                              Crystal &crystal) {
 
+  Kokkos::Profiling::pushRegion("parseFromPhono3py");
+
 #ifndef HDF5_AVAIL
-  Error(
-      "Phono3py HDF5 output cannot be read if Phoebe is not built with HDF5.");
+  Error("Phono3py HDF5 output cannot be read if Phoebe is not built with HDF5.");
   // return void;
 #else
 
@@ -635,6 +639,7 @@ Interaction3Ph IFC3Parser::parseFromPhono3py(Context &context,
   Interaction3Ph interaction3Ph(crystal, FC3, bravaisVectors2, bravaisVectors3,
                                 weights2, weights3);
 
+  Kokkos::Profiling::popRegion();
   return interaction3Ph;
 
 #endif
@@ -642,6 +647,8 @@ Interaction3Ph IFC3Parser::parseFromPhono3py(Context &context,
 
 Interaction3Ph IFC3Parser::parseFromShengBTE(Context &context,
                                              Crystal &crystal) {
+
+  Kokkos::Profiling::pushRegion("parseFromShengBTE");
 
   auto fileName = context.getPhFC3FileName();
 
@@ -828,5 +835,6 @@ Interaction3Ph IFC3Parser::parseFromShengBTE(Context &context,
                  "ShengBTE files.\n"
               << std::endl;
   }
+  Kokkos::Profiling::popRegion();
   return interaction3Ph;
 }

--- a/src/parser/phonopy_input_parser.cpp
+++ b/src/parser/phonopy_input_parser.cpp
@@ -34,6 +34,8 @@ int findRIndex(Eigen::MatrixXd &cellPositions2, Eigen::Vector3d &position2) {
 
 std::tuple<Crystal, PhononH0> PhonopyParser::parsePhHarmonic(Context &context) {
 
+  Kokkos::Profiling::pushRegion("parsePhHarmonic");
+
   // Here read the real space dynamical matrix of inter-atomic force constants
   if (mpi->mpiHead()) {
     std::cout << "Using harmonic force constants from phonopy." << std::endl;
@@ -563,6 +565,7 @@ std::tuple<Crystal, PhononH0> PhonopyParser::parsePhHarmonic(Context &context) {
   PhononH0 dynamicalMatrix(crystal, dielectricMatrix, bornCharges,
                            forceConstants, context.getSumRuleFC2());
 
+  Kokkos::Profiling::popRegion();
   return std::make_tuple(crystal, dynamicalMatrix);
 #endif
 }

--- a/src/parser/qe_input_parser.cpp
+++ b/src/parser/qe_input_parser.cpp
@@ -386,6 +386,8 @@ std::tuple<Crystal, PhononH0> QEParser::parsePhHarmonic(Context &context) {
   //  Here we read the dynamical matrix of inter-atomic force constants
   //	in real space.
 
+  Kokkos::Profiling::pushRegion("parsePhHarmonic (QE)");
+
   std::string fileName = context.getPhFC2FileName();
   if (fileName.empty()) {
     Error("Must provide a FC2 file name");
@@ -558,12 +560,15 @@ std::tuple<Crystal, PhononH0> QEParser::parsePhHarmonic(Context &context) {
   PhononH0 dynamicalMatrix(crystal, dielectricMatrix, bornCharges,
                            forceConstants, context.getSumRuleFC2());
 
+  Kokkos::Profiling::popRegion();
   return std::make_tuple(crystal, dynamicalMatrix);
 }
 
 std::tuple<Crystal, ElectronH0Fourier>
 QEParser::parseElHarmonicFourier(Context &context) {
   //  Here we read the XML file of quantum espresso.
+
+  Kokkos::Profiling::pushRegion("parseElHarmonicFourier (QE)");
 
   std::string fileName = context.getElectronH0Name();
   double fourierCutoff = context.getElectronFourierCutoff();
@@ -796,6 +801,7 @@ QEParser::parseElHarmonicFourier(Context &context) {
   ElectronH0Fourier electronH0(crystal, coarsePoints, coarseBandStructure,
                                fourierCutoff);
 
+  Kokkos::Profiling::popRegion();
   return std::make_tuple(crystal, electronH0);
 }
 
@@ -803,6 +809,8 @@ std::pair<Eigen::Tensor<double, 3>,
           Eigen::Tensor<double, 5>> parseWSVecFromWannier90(
     const std::string &fileName, const int &numWannier,
     const int &numVectors, const Eigen::Matrix3d &directUnitCell) {
+
+  Kokkos::Profiling::pushRegion("parseWSVecFromWannier90");
 
   if (fileName.empty()) {
     Error("Must provide the Wannier90 WsVec file name");
@@ -866,11 +874,15 @@ std::pair<Eigen::Tensor<double, 3>,
     }
   }
 
+  Kokkos::Profiling::popRegion();
   return std::make_pair(degeneracyShifts, phaseShifts);
 }
 
 std::tuple<Crystal, ElectronH0Wannier>
 QEParser::parseElHarmonicWannier(Context &context, Crystal *inCrystal) {
+
+  Kokkos::Profiling::pushRegion("parseElHarmonicWannier (QE)");
+
   //  Here we read the XML file of quantum espresso.
 
   std::string fileName = context.getElectronH0Name();
@@ -1025,6 +1037,7 @@ QEParser::parseElHarmonicWannier(Context &context, Crystal *inCrystal) {
   }
 
   if (inCrystal != nullptr) {
+    Kokkos::Profiling::popRegion();
     return std::make_tuple(*inCrystal, electronH0);
   } else {
     Eigen::MatrixXd atomicPositions = context.getInputAtomicPositions();
@@ -1042,6 +1055,7 @@ QEParser::parseElHarmonicWannier(Context &context, Crystal *inCrystal) {
     Crystal crystal(context, directUnitCell, atomicPositions, atomicSpecies,
                     speciesNames, speciesMasses);
     crystal.print();
+    Kokkos::Profiling::popRegion();
     return std::make_tuple(crystal, electronH0);
   }
 }

--- a/src/statistics_sweep.cpp
+++ b/src/statistics_sweep.cpp
@@ -17,6 +17,8 @@ StatisticsSweep::StatisticsSweep(Context &context,
                         ? fullBandStructure->getIsDistributed()
                         : false) {
 
+  Kokkos::Profiling::pushRegion("StatisticsSweep constructor");
+
   Eigen::VectorXd temperatures = context.getTemperatures();
   nTemp = int(temperatures.size());
   if (nTemp == 0) {
@@ -207,8 +209,8 @@ StatisticsSweep::StatisticsSweep(Context &context,
     infoCalculations = calcTable;
     numCalculations = int(calcTable.rows());
   }
-
   printInfo();
+  Kokkos::Profiling::popRegion();
 }
 
 // copy constructor


### PR DESCRIPTION
This PR replaces a 5D kokkos for loop with a kokkos::gemv call, which in some cases can result in a dramatic speedup of elph calculations. 

Thanks to @anjohan for the suggestion and help on this PR. 