### PR TITLE
Switch manual tranpose of distributed matrix for ScaLAPACK pdtran

### DIFF
--- a/src/algebra/Blacs.h
+++ b/src/algebra/Blacs.h
@@ -61,6 +61,8 @@ void pdsyevr_(const char*, const char*, const char*, const int*, double*, int*, 
 // calculate all eigenvalues and vectors by divide and conquer algorithm
 void pdsyevd_(char *, char *, int *, double *, int *, int *, int *, double *,
              double *, int *, int *, int *, double *, int *, int *, int *, int *);
+// take the transpose of a real matrix
+void pdtran_(int * m, int * n, double * alpha, double * a, int * ia, int * ja, int * desc_a, double * beta, double * c, int * ic, int * jc, int * desc_c);
 
 }
 

--- a/src/algebra/Matrix.cpp
+++ b/src/algebra/Matrix.cpp
@@ -99,3 +99,10 @@ double Matrix<std::complex<double>>::norm() {
   }
   else{ return mat->norm(); }
 }
+
+template <>
+void Matrix<double>::symmetrize() {
+  if(isDistributed) { return pmat->symmetrize(); }
+  else{ return mat->symmetrize(); }
+}
+

--- a/src/algebra/Matrix.h
+++ b/src/algebra/Matrix.h
@@ -182,6 +182,11 @@ class Matrix {
   /** Unary negation
    */
   Matrix<T> operator-() const;
+
+  /** Symmetrize the matrix
+  */
+  void symmetrize();
+
 };
 
 /* ------------------ constructor implementations -------------- */

--- a/src/algebra/PMatrix.h
+++ b/src/algebra/PMatrix.h
@@ -236,6 +236,11 @@ class ParallelMatrix {
   /** Unary negation
    */
   ParallelMatrix<T> operator-() const;
+
+  /** Symmetrize the matrix with pdtran for transpose, (A + A^T)/2
+  */
+  void symmetrize();
+
 };
 
 template <typename T>

--- a/src/algebra/SMatrix.cpp
+++ b/src/algebra/SMatrix.cpp
@@ -96,7 +96,7 @@ std::tuple<std::vector<double>, SerialMatrix<double>>
 
     Warning("Partial eigenvalue diagonalization currently not implemented "
                 "for the serial case. Reporting all eigenvalues.");
-    diagonalize();
+    return diagonalize();
 }
 
 // Explicit specialization of norm for doubles
@@ -118,3 +118,22 @@ double SerialMatrix<std::complex<double>>::norm() {
   std::vector<double> work(numRows_);
   return zlange_(&norm, &nr, &nc, this->mat, &nr, &work[0]);
 }
+
+// executes A + AT/2
+template <>
+void SerialMatrix<double>::symmetrize() {
+
+  if (numRows_ != numCols_) {
+    Error("Cannot currently symmetrize a non-square matrix.");
+  }
+
+  for (int i = 0; i<numRows_; i++) {
+    for (int j = i; j<numCols_; j++) {
+
+      double temp = (this->operator()(j,i) + this->operator()(i,j))/2.;
+      this->operator()(i,j) = temp;
+      this->operator()(j,i) = temp;
+    }
+  }
+}
+

--- a/src/algebra/SMatrix.h
+++ b/src/algebra/SMatrix.h
@@ -185,6 +185,10 @@ class SerialMatrix {
   /** Unary negation
    */
   SerialMatrix<T> operator-() const;
+
+  /** Symmetrize the matrix */
+  void symmetrize();
+
 };
 
 // A default constructor to build a dense matrix of zeros to be filled

--- a/src/bte/scattering.cpp
+++ b/src/bte/scattering.cpp
@@ -1137,6 +1137,7 @@ ScatteringMatrix::getSMatrixIndex(const int &iMat) {
 }
 
 void ScatteringMatrix::symmetrize() {
+
   // note: if the matrix is not stored in memory, it's not trivial to enforce
   // that the matrix is symmetric
 
@@ -1147,76 +1148,10 @@ void ScatteringMatrix::symmetrize() {
   }
 
   if (highMemory) {
-    ParallelMatrix<double> newMatrix = theMatrix;
-    newMatrix *= 0.;
-
-    for (int iRank = 0; iRank < mpi->getSize(); iRank++) {
-      int thisSize = 0;
-      if (iRank == mpi->getRank()) {
-        thisSize = int(theMatrix.getAllLocalStates().size());
-      }
-      mpi->allReduceSum(&thisSize);
-
-      std::vector<int> index1(thisSize, 0);
-      std::vector<int> index2(thisSize, 0);
-      std::vector<int> index3(thisSize, 0);
-      std::vector<int> index4(thisSize, 0);
-
-      if (iRank == mpi->getRank()) {
-        auto allLocalStates = theMatrix.getAllLocalStates();
-        size_t numAllLocalStates = allLocalStates.size();
-
-        for (size_t i=0; i<numAllLocalStates; i++) {
-          auto tup = allLocalStates[i];
-          int iMat1 = std::get<0>(tup);
-          int iMat2 = std::get<1>(tup);
-          int jMat1, jMat2;
-//          if (context.getUseSymmetries()) {
-//            Error("Symmetrization of the scattering matrix with symmetries"
-//                  " is not verified");
-//            // The matrix may not be symmetric
-//
-//            auto t1 = getSMatrixIndex(iMat1);
-//            auto t2 = getSMatrixIndex(iMat2);
-//            BteIndex iBte1 = std::get<0>(t1);
-//            BteIndex iBte2 = std::get<0>(t2);
-//            CartIndex ii = std::get<1>(t1);
-//            CartIndex jj = std::get<1>(t2);
-//            jMat1 = getSMatrixIndex(iBte1, ii);
-//            jMat2 = getSMatrixIndex(iBte2, jj);
-//          } else {
-          jMat1 = iMat1;
-          jMat2 = iMat2;
-//          }
-
-          index1[i] = iMat1;
-          index2[i] = iMat2;
-          index3[i] = jMat2;
-          index4[i] = jMat1;
-        }
-      }
-
-      mpi->allReduceSum(&index1);
-      mpi->allReduceSum(&index2);
-      mpi->allReduceSum(&index3);
-      mpi->allReduceSum(&index4);
-
-      std::vector<double> values(thisSize, 0.);
-#pragma omp parallel for
-      for (int i = 0; i < thisSize; i++) {
-        values[i] = (theMatrix(index1[i], index2[i]) +
-                     theMatrix(index3[i], index4[i])) *
-                    0.5;
-      }
-      mpi->allReduceSum(&values);
-
-#pragma omp parallel for
-      for (int i = 0; i < thisSize; i++) {
-        newMatrix(index1[i], index2[i]) = values[i];
-        newMatrix(index3[i], index4[i]) = values[i];
-      }
-    }
-    theMatrix = newMatrix;
+    theMatrix.symmetrize();
+  } else {
+    Warning("The symmetrization of the scattering matrix is not\n"
+            "implemented when it is not stored in memory.");
   }
 }
 


### PR DESCRIPTION
Earlier, we were using a transpose of the distributed scattering matrix with an explicit/hand written call. 
This was super slow, and should have been implemented using the ScaLAPACK pdtran function. 

This PR rectifies this for a serious speedup on the symmetrization of the matrix, which is (A+A^T)/2 and is necessary to get a good result from the relaxons solver. 