### PR TITLE
Quick fix to get around a very recent Eigen bug

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -47,7 +47,7 @@ ExternalProject_Add(pugixml_dep
 ExternalProject_Add(eigen_dep
     SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/eigen_src
     GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-    GIT_TAG 3.4
+    GIT_TAG 3.4.0
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""

--- a/src/statistics_sweep.cpp
+++ b/src/statistics_sweep.cpp
@@ -289,8 +289,8 @@ StatisticsSweep::findChemicalPotentialFromDoping(const double &doping,
           "numBands: " + std::to_string(numBands) + " numElectrons: " + std::to_string(numElectronsDoped)
           + "\nThis likely means you've selected a non-physical doping value, such as\n"
           "a very small doping for a metal, or you didn't Wannierize enough bands."
-          "\nThis can also happen if you had bands under your disentanglement window which"
-          "you did not cut out using exclude_bands in Wannier90. See a note about this in the elphWannier tutorial.");
+          "\nThis can also happen if you had bands under your disentanglement window which\n"
+          "were not excluded using exclude_bands in Wannier90.\nSee a note about this in the elphWannier tutorial.");
   }
   if (numElectronsDoped < 0.) {
     Error("The number of occupied states is negative");

--- a/src/statistics_sweep.cpp
+++ b/src/statistics_sweep.cpp
@@ -379,6 +379,9 @@ double StatisticsSweep::findDopingFromChemicalPotential(
   if (isDistributed) mpi->allReduceSum(&fPop);
   fPop /= double(numPoints);
   double doping = (occupiedStates - fPop);
+  // here we save doping in 1/cm^3 because doping is never used 
+  // internally for calculations, with the exception of converting sigma->mu at the very end. 
+  // this is only for printing to file later. 
   doping *= spinFactor / volume / pow(distanceBohrToCm, 3);
   return doping;
 }

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -41,6 +41,9 @@ std::tuple<int, int> decompress2Indices(const int &iTot, const int &size1,
 }
 
 std::tuple<double, double> memoryUsage() {
+
+  // based on: https://www.tutorialspoint.com/how-to-get-memory-usage-under-linux-in-cplusplus
+  // see https://man7.org/linux/man-pages/man5/proc.5.html
   double vm_usage = 0.;
   double resident_set = 0.;
   std::ifstream stat_stream("/proc/self/stat",


### PR DESCRIPTION
After commit 61ce777c2665c73b65dadf3825dfe7f7bafc4839 to Eigen's 3.4 branch, Phoebe no longer builds and instead fails with: 

```
/mnt/home/jcoulter/WORK/coupledPhoebe/build/eigen_src/unsupported/Eigen/CXX11/Tensor:22:10: fatal error: ../../../Eigen/src/Core/util/MaxSizeVector.h: No such file or directory
  22 | #include "../../../Eigen/src/Core/util/MaxSizeVector.h"
```
This is a quick workaround (switching to another branch named 3.4.0 instead of 3.4) so that Phoebe again can build and use Eigen properly. 

Other changes in this PR are only minor changes in output formatting and the addition of a few comments. 