### PR TITLE
Fix CMake policy issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ cmake_minimum_required(VERSION 3.16)
 # set cpp standard flags
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
-cmake_policy(SET CMP0144 NEW)
 
 project(Phoebe LANGUAGES C CXX Fortran VERSION 1.0)
 


### PR DESCRIPTION
Remove a line in CMakeLists which prevents builds from working in newer versions