### PR TITLE
Update spglib to use FetchContent in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,12 +61,12 @@ add_executable(runTests ${TEST_SOURCES} ${SOURCE_FILES})
 set_target_properties(runTests PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
 # dependencies
-add_dependencies(phoebe spglib_dep pugixml_dep eigen_dep)
-add_dependencies(runTests spglib_dep pugixml_dep eigen_dep)
+add_dependencies(phoebe pugixml_dep eigen_dep)
+add_dependencies(runTests pugixml_dep eigen_dep)
 
-target_link_libraries(phoebe symspg pugixml kokkos Kokkos::kokkoskernels nlohmann_json::nlohmann_json)
+target_link_libraries(phoebe Spglib::symspg pugixml kokkos Kokkos::kokkoskernels nlohmann_json::nlohmann_json)
 enable_testing()
-target_link_libraries(runTests symspg pugixml gtest_main kokkos Kokkos::kokkoskernels nlohmann_json::nlohmann_json)
+target_link_libraries(runTests Spglib::symspg pugixml gtest_main kokkos Kokkos::kokkoskernels nlohmann_json::nlohmann_json)
 
 gtest_discover_tests(
     runTests

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,18 +22,14 @@ FetchContent_Declare(json
 )
 FetchContent_MakeAvailable(json)
 
-ExternalProject_Add(spglib_dep
-    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/spglib_build
-    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/spglib_src
-    GIT_REPOSITORY https://github.com/spglib/spglib.git
-    GIT_TAG develop
-    INSTALL_COMMAND ""
-    UPDATE_COMMAND ""
-    CMAKE_ARGS
-	-DUSE_OMP=${OMP_AVAIL}
-        -DCMAKE_BUILD_TYPE=Release
-        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+FetchContent_Declare(
+	Spglib
+	GIT_REPOSITORY https://github.com/spglib/spglib
+	GIT_TAG develop
+	UPDATE_COMMAND ""
 )
+set(SPGLIB_USE_OMP ON)
+FetchContent_MakeAvailable(Spglib)
 
 ExternalProject_Add(pugixml_dep
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/pugixml_build

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -26,6 +26,7 @@ ExternalProject_Add(spglib_dep
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/spglib_build
     SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/spglib_src
     GIT_REPOSITORY https://github.com/spglib/spglib.git
+    GIT_TAG develop
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""
     CMAKE_ARGS


### PR DESCRIPTION
Summary: A quick fix to update Spglib to use FetchContent in CMakeLists, as the old way ceased to work and prevented the project from building. 