### PR TITLE
Update clone links in various tutorials to match current org structure

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -1,5 +1,5 @@
-name: Build and Test
-on: [push, pull_request]
+name: Build and Test (PR)
+on: [pull_request]
 
 jobs:
   build:
@@ -10,21 +10,21 @@ jobs:
         mpi: [OFF, ON]
         compiler:
           [
-            "GCC 10",
-            "GCC 13",
+            #"GCC 10",
+            "GCC 14",
             "Clang 15",
-            "Clang 11",
+            #"Clang 11",
           ]
     env:
       OMP_NUM_THREADS: 4
-    name: "Ubuntu 22.04 ( ${{ matrix.compiler  }} OpenMP ( ${{ matrix.omp }} ) , MPI ( ${{ matrix.mpi }} ))"
-    runs-on: ubuntu-22.04
+    name: "Ubuntu 24.04 ( ${{ matrix.compiler  }} OpenMP ( ${{ matrix.omp }} ) , MPI ( ${{ matrix.mpi }} ))"
+    runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt install -y libopenblas-dev liblapack-dev libhdf5-dev libhdf5-openmpi-dev libscalapack-openmpi-dev python3-pip gfortran cmake -o Acquire::Retries=3 --fix-missing
-          pip3 install numpy
+          pip3 install numpy --break-system-packages
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -34,21 +34,21 @@ jobs:
         run: |
           CC_VERSION=$( echo "${{ matrix.compiler }}" | awk '{ print $2; }')
           echo "CC_VERSION=${CC_VERSION}" >> "$GITHUB_OUTPUT"
-      - name: Install GCC
+      - name: Install GCC 
         if: ${{ startsWith(matrix.compiler, 'GCC') }}
-        run: sudo apt install -y g++-${{ steps.extract_matrix.outputs.CC_VERSION }}
+        run: sudo apt install -y g++ #-${{ steps.extract_matrix.outputs.CC_VERSION }}
       - name: Install Clang
         if: ${{ startsWith(matrix.compiler, 'Clang') }}
         run: |
-          sudo apt install -y clang-${{ steps.extract_matrix.outputs.CC_VERSION }}
-          sudo apt install -y libomp-${{ steps.extract_matrix.outputs.CC_VERSION }}-dev
+          sudo apt install -y clang #-${{ steps.extract_matrix.outputs.CC_VERSION }}
+          sudo apt install -y libomp-dev #${{ steps.extract_matrix.outputs.CC_VERSION }}-dev
       - name: Configure
         run: |
           CC_NAME=$(echo "${{ matrix.compiler }}" | awk '{ print tolower($1); }')
           CC_VER=$( echo "${{ matrix.compiler }}" | awk '{ print $2; }')
           test "${CC_NAME}" = "gcc" && CC_EXE="g++"
           test "${CC_NAME}" = "clang" && CC_EXE="clang++"
-          cmake -S . -B build -DCMAKE_CXX_COMPILER="${CC_EXE}-${CC_VER}" -DOMP_AVAIL=${{ matrix.omp }} -DKokkos_ENABLE_OPENMP=${{ matrix.omp }} -DMPI_AVAIL=${{ matrix.mpi }} -DHDF5_AVAIL=ON
+          cmake -S . -B build -DCMAKE_CXX_COMPILER="${CC_EXE}" -DOMP_AVAIL=${{ matrix.omp }} -DKokkos_ENABLE_OPENMP=${{ matrix.omp }} -DMPI_AVAIL=${{ matrix.mpi }} -DHDF5_AVAIL=ON
       - name: Build
         run: cmake --build build -- -j4
       - name: Build Test
@@ -58,9 +58,9 @@ jobs:
           cd build
           ./runTests
       - name: Download test data
-        if: ${{ matrix.compiler == 'GCC 10' }}
+        if: ${{ matrix.compiler == 'GCC 14' }}
         run: |
-          wget github.com/phoebe-team/phoebe-data/archive/master.zip
+          wget github.com/mir-group/phoebe-data/archive/master.zip
           unzip -j master.zip "phoebe-data-master/example/Silicon-ph/qe-phonons/*" -d "example/Silicon-ph/qe-phonons"
           unzip -j master.zip "phoebe-data-master/example/Silicon-ph/qe-ph-anharmonic/*" -d "example/Silicon-ph/thirdorder.py-anharmonic"
           unzip -j master.zip "phoebe-data-master/example/Silicon-el/qe-elph/*" -d "example/Silicon-el/qe-elph"
@@ -69,7 +69,7 @@ jobs:
           mkdir example/Silicon-epa/qe-elph/out
           unzip -j master.zip "phoebe-data-master/example/Silicon-epa/qe-elph/out/*" -d "example/Silicon-epa/qe-elph/out"
       - name: Run epa example without MPI
-        if: ${{ matrix.compiler == 'GCC 10' }}
+        if: ${{ matrix.compiler == 'GCC 14' }}
         working-directory: example/Silicon-epa
         run: |
           ../../build/phoebe -in qeToPhoebeEPA.in
@@ -78,7 +78,7 @@ jobs:
           ../../build/phoebe -in electronFourierDos.in
           python3 reference/run_check.py
       - name: Run epa example with MPI
-        if: ${{ matrix.compiler == 'GCC 10' && matrix.mpi == 'ON'}}
+        if: ${{ matrix.compiler == 'GCC 14' && matrix.mpi == 'ON'}}
         working-directory: example/Silicon-epa
         run: |
           mpirun -np 4 --oversubscribe ../../build/phoebe -in epaTransport.in
@@ -86,7 +86,7 @@ jobs:
           mpirun -np 4 --oversubscribe ../../build/phoebe -in electronFourierDos.in
           python3 reference/run_check.py
       - name: Run ph example without MPI
-        if: ${{ matrix.compiler == 'GCC 10' }}
+        if: ${{ matrix.compiler == 'GCC 14' }}
         working-directory: example/Silicon-ph
         run: |
           ../../build/phoebe -in phononTransport.in
@@ -95,7 +95,7 @@ jobs:
           ../../build/phoebe -in phononLifetimes.in
           python3 reference/run_check.py
       - name: Run ph example with MPI
-        if: ${{ matrix.compiler == 'GCC 10' && matrix.mpi == 'ON' }}
+        if: ${{ matrix.compiler == 'GCC 14' && matrix.mpi == 'ON' }}
         working-directory: example/Silicon-ph
         run: |
           mpirun -np 4 --oversubscribe ../../build/phoebe -in phononTransport.in
@@ -104,7 +104,7 @@ jobs:
           mpirun -np 4 --oversubscribe ../../build/phoebe -in phononLifetimes.in
           python3 reference/run_check.py
       - name: Run el example without MPI
-        if: ${{ matrix.compiler == 'GCC 10' }}
+        if: ${{ matrix.compiler == 'GCC 14' }}
         working-directory: example/Silicon-el
         run: |
           ../../build/phoebe -in qeToPhoebeWannier.in
@@ -114,7 +114,7 @@ jobs:
           ../../build/phoebe -in electronLifetimes.in
           python3 reference/run_check.py
       - name: Run el example with MPI
-        if: ${{ matrix.compiler == 'GCC 10' && matrix.mpi == 'ON' }}
+        if: ${{ matrix.compiler == 'GCC 14' && matrix.mpi == 'ON' }}
         working-directory: example/Silicon-el
         run: |
           # Note: don't run this as it runs out-of-memory on the VM

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Download test data
         if: ${{ matrix.compiler == 'GCC 10' }}
         run: |
-          wget github.com/mir-group/phoebe-data/archive/master.zip
+          wget github.com/phoebe-team/phoebe-data/archive/master.zip
           unzip -j master.zip "phoebe-data-master/example/Silicon-ph/qe-phonons/*" -d "example/Silicon-ph/qe-phonons"
           unzip -j master.zip "phoebe-data-master/example/Silicon-ph/qe-ph-anharmonic/*" -d "example/Silicon-ph/thirdorder.py-anharmonic"
           unzip -j master.zip "phoebe-data-master/example/Silicon-el/qe-elph/*" -d "example/Silicon-el/qe-elph"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,7 +24,7 @@ authors:
 cff-version: "1.1.0"
 license: "MIT License"
 message: "If you use this software, please cite it using these metadata."
-repository-code: "https://github.com/mir-group/phoebe"
+repository-code: "https://github.com/phoebe-team/phoebe"
 title: "Phoebe: a high-performance framework for solving phonon and electron Boltzmann transport equations"
 version: "1.0"
 ...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build and Test](https://github.com/mir-group/phoebe/workflows/Build%20and%20Test/badge.svg)
+![Build and Test](https://github.com/phoebe-team/phoebe/workflows/Build%20and%20Test/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/phoebe/badge/?version=develop)](https://phoebe.readthedocs.io/en/develop/?badge=develop)
 
 # Phoebe <img src="doc/sphinx/source/_static/icon.png" width="25"/>
@@ -16,7 +16,7 @@ For more details, see:
   [DOI:10.1088/2515-7639/ac86f6](https://doi.org/10.1088/2515-7639/ac86f6).
 
 Tutorials, documentation of functionality and underlying theory can be found at:
-  * [Homepage](https://mir-group.github.io/phoebe/)
+  * [Homepage](https://phoebe-team.github.io/phoebe/)
   * [Tutorials/Documentation](https://phoebe.readthedocs.io/en/develop/introduction.html)
 
 For further questions and feature requests, please post on the discussions page for the git repo.

--- a/doc/doxygen/doc_pages/qe_patch.md
+++ b/doc/doxygen/doc_pages/qe_patch.md
@@ -4,7 +4,7 @@ As explained in the theory section about the electron-phonon coupling with Wanni
 
 @section fcode Fortran code
 
-The code is modified on a separate git repository available [at this link](https://github.com/mir-group/phoebe-quantum-espresso/).
+The code is modified on a separate git repository available [at this link](https://github.com/phoebe-team/phoebe-quantum-espresso/).
 This repository is a fork from the official QE repository.
 To develop a new patch or update it to the latest QE version, remember to pull from the remote quantum espresso repository.
 For the first Phoebe release, we only patched the latest QE 6.6 version, although a retrofit should be doable.

--- a/doc/sphinx/source/installation.rst
+++ b/doc/sphinx/source/installation.rst
@@ -6,7 +6,7 @@ Installing Phoebe
 Download
 --------
 
-The code is available (free of charge with an open-source MIT license) at its `github page <https://github.com/mir-group/phoebe>`__.
+The code is available (free of charge with an open-source MIT license) at its `github page <https://github.com/phoebe-team/phoebe>`__.
 When checking out from the GitHub repository, make sure to use the master branch. The other branches may be functional, but are not guaranteed to work and should be used with caution.
 
 Prerequisites
@@ -40,7 +40,7 @@ Basic build
 To install Phoebe, type::
 
   # clone the git repository, including the Kokkos submodule
-  git clone --recurse-submodules https://github.com/mir-group/phoebe.git
+  git clone --recurse-submodules https://github.com/phoebe-team/phoebe.git
   cd phoebe
   # build the code
   mkdir build

--- a/doc/sphinx/source/tutorials/elEpaTransport.rst
+++ b/doc/sphinx/source/tutorials/elEpaTransport.rst
@@ -19,7 +19,7 @@ To do this, we must compile a new copy of Quantum ESPRESSO.
 From an installation folder of your choice, type::
 
     # download the patched version
-    git clone https://github.com/mir-group/phoebe-quantum-espresso.git
+    git clone https://github.com/phoebe-team/phoebe-quantum-espresso.git
     cd phoebe-quantum-espresso
     # install it
     git checkout phoebe-qe-7.0

--- a/doc/sphinx/source/tutorials/elWanTransport.rst
+++ b/doc/sphinx/source/tutorials/elWanTransport.rst
@@ -22,7 +22,7 @@ To do this, we must compile a new copy of Quantum ESPRESSO.
 From an installation folder of your choice, type::
 
     # download the patched version
-    git clone https://github.com/mir-group/phoebe-quantum-espresso.git
+    git clone https://github.com/phoebe-team/phoebe-quantum-espresso.git
     cd phoebe-quantum-espresso
     # install it
     git checkout phoebe-qe-7.0

--- a/scripts/developerScripts/localBuildAndTest.sh
+++ b/scripts/developerScripts/localBuildAndTest.sh
@@ -34,7 +34,7 @@ PHOEBE_DIR="phoebe/"
 # pull down the code
 if ${BUILD}
 then
-  git clone git@github.com:mir-group/phoebe.git
+  git clone git@github.com:phoebe-team/phoebe.git
   cd phoebe
   git submodule update --init
   mkdir build
@@ -49,7 +49,7 @@ fi
 if ${DOWNLOAD}
 then
   cd phoebe
-  wget github.com/mir-group/phoebe-data/archive/master.zip
+  wget github.com/phoebe-team/phoebe-data/archive/master.zip
   unzip -j master.zip "phoebe-data-master/example/Silicon-ph/qe-phonons/*" -d "example/Silicon-ph/qe-phonons"
   unzip -j master.zip "phoebe-data-master/example/Silicon-ph/qe-ph-anharmonic/*" -d "example/Silicon-ph/thirdorder.py-anharmonic"
   unzip -j master.zip "phoebe-data-master/example/Silicon-el/qe-elph/*" -d "example/Silicon-el/qe-elph"

--- a/scripts/sampleBuildScripts/perlmutter.sh
+++ b/scripts/sampleBuildScripts/perlmutter.sh
@@ -12,7 +12,7 @@ make PREFIX=$HOME/.local install
 cd ../
 
 # clone phoebe
-git clone --recursive https://github.com/mir-group/phoebe.git
+git clone --recursive https://github.com/phoebe-team/phoebe.git
 cd phoebe
 mkdir build
 cd build


### PR DESCRIPTION
Simple update of links to avoid confusion -- mostly, they already redirected properly, but this is more straightforward for users. 