### PR TITLE
Independent k/q meshes in RTA case, improve storage of velocities in memory 

### DIFF
--- a/src/apps/electron_wannier_transport_app.cpp
+++ b/src/apps/electron_wannier_transport_app.cpp
@@ -71,9 +71,13 @@ void ElectronWannierTransportApp::run(Context &context) {
     Eigen::Vector3i qMesh = context.getQMesh();
     Eigen::Vector3i kMesh = context.getKMesh();
 
-    if(qMesh.prod() == 0) {
+    if(qMesh.prod() == 0 || qMesh == kMesh ) {
       Warning("When running RTA, if qMesh is not set, we default to using the kMesh,\n"
               "This may be more expensive than needed.");
+
+      // use the same bandstructure
+      innerBandStructure = std::make_shared<ActiveBandStructure>(bandStructure);
+    
     } else { // check that the k and q meshes are commensurate 
 
       if( kMesh(0)%qMesh(0) != 0 || kMesh(1)%qMesh(1) != 0 || kMesh(2)%qMesh(2) != 0 ) {

--- a/src/apps/electron_wannier_transport_app.cpp
+++ b/src/apps/electron_wannier_transport_app.cpp
@@ -64,7 +64,7 @@ void ElectronWannierTransportApp::run(Context &context) {
   // This is a less dense K mesh of final states for RTA, the mesh 
   // corresponds to what we will use for the phonon sampling
   // In the RTA only case () 
-  std::shared_ptr<BaseBandStructure> innerBandStructure;  
+  std::shared_ptr<ActiveBandStructure> innerBandStructure;  
 
   if(!context.getScatteringMatrixInMemory()) {
 
@@ -94,7 +94,7 @@ void ElectronWannierTransportApp::run(Context &context) {
   }
 
   ElScatteringMatrix scatteringMatrix(context, statisticsSweep, 
-                                      *innerBandStructure, bandStructure,
+                                      *innerBandStructure.get(), bandStructure,
                                       phononH0, &couplingElPh);
 
   scatteringMatrix.setup();

--- a/src/bands/active_bandstructure.cpp
+++ b/src/bands/active_bandstructure.cpp
@@ -65,8 +65,25 @@ ActiveBandStructure::ActiveBandStructure(const Points &points_,
   hasEigenvectors = withEigenvectors;
 
   energies.resize(numPoints * numFullBands, 0.);
-  if(withVelocities) velocities.resize(numPoints * numFullBands * numFullBands * 3, complexZero);
-  if(withEigenvectors) eigenvectors.resize(numPoints * numFullBands * numFullBands, complexZero);
+
+  if (withVelocities) {
+    try {
+      size_t size = size_t(numPoints) * size_t(numFullBands) * size_t(numFullBands) * size_t(3);
+      velocities.resize(size);
+    } catch(std::length_error &) {
+      Error("Failed to allocate band structure velocities.\n"
+        "You are exceeding the number of states which can be stored as an integer value.");
+    }
+  }
+  if (withEigenvectors) {
+    try {
+      size_t size = size_t(numPoints) * size_t(numFullBands) * size_t(numFullBands);
+      eigenvectors.resize(size);
+    } catch(std::length_error &) {
+      Error("Failed to allocate band structure eignevectors.\n"
+        "You are exceeding the number of states which can be stored as an integer value.");
+    }
+  }
 
   windowMethod = Window::nothing;
   buildIndices();

--- a/src/bands/active_bandstructure.cpp
+++ b/src/bands/active_bandstructure.cpp
@@ -64,7 +64,7 @@ ActiveBandStructure::ActiveBandStructure(const Points &points_,
   numStates = numFullBands * numPoints;
   hasEigenvectors = withEigenvectors;
 
-  energies.resize(numPoints * numFullBands, 0.);
+  energies.resize(size_t(numPoints) * size_t(numFullBands), 0.);
 
   if (withVelocities) {
     try {
@@ -669,10 +669,10 @@ void ActiveBandStructure::buildOnTheFly(Window &window, Points points_,
   // this isn't a constant number.
   // Also, we look for the size of the arrays containing band structure.
   numBands = Eigen::VectorXi::Zero(numPoints);
-  int numEnStates = 0;
-  int numVelStates = 0;
-  int numEigStates = 0;
-  for (int ik = 0; ik < numPoints; ik++) {
+  size_t numEnStates = 0;
+  size_t numVelStates = 0;
+  size_t numEigStates = 0;
+  for (size_t ik = 0; ik < numPoints; ik++) {
     numBands(ik) = filteredBands(ik, 1) - filteredBands(ik, 0) + 1;
     numEnStates += numBands(ik);
     numVelStates += 3 * numBands(ik) * numBands(ik);
@@ -962,9 +962,9 @@ StatisticsSweep ActiveBandStructure::buildAsPostprocessing(
   // this isn't a constant number.
   // Also, we look for the size of the arrays containing band structure.
   numBands = Eigen::VectorXi::Zero(numPoints);
-  int numEnStates = 0;
-  int numVelStates = 0;
-  int numEigStates = 0;
+  size_t numEnStates = 0;
+  size_t numVelStates = 0;
+  size_t numEigStates = 0;
   for (int ik = 0; ik < numPoints; ik++) {
     numBands(ik) = filteredBands(ik, 1) - filteredBands(ik, 0) + 1;
     numEnStates += numBands(ik);

--- a/src/bands/active_bandstructure.cpp
+++ b/src/bands/active_bandstructure.cpp
@@ -70,18 +70,18 @@ ActiveBandStructure::ActiveBandStructure(const Points &points_,
     try {
       size_t size = size_t(numPoints) * size_t(numFullBands) * size_t(numFullBands) * size_t(3);
       velocities.resize(size);
-    } catch(std::length_error &) {
+    } catch(std::bad_alloc &) {
       Error("Failed to allocate band structure velocities.\n"
-        "You are exceeding the number of states which can be stored as an integer value.");
+        "You are likely running out of memory.");
     }
   }
   if (withEigenvectors) {
     try {
       size_t size = size_t(numPoints) * size_t(numFullBands) * size_t(numFullBands);
       eigenvectors.resize(size);
-    } catch(std::length_error &) {
+    } catch(std::bad_alloc &) {
       Error("Failed to allocate band structure eignevectors.\n"
-        "You are exceeding the number of states which can be stored as an integer value.");
+        "You are likely running out of memory.");
     }
   }
 

--- a/src/bands/bandstructure.cpp
+++ b/src/bands/bandstructure.cpp
@@ -213,6 +213,11 @@ Eigen::VectorXd FullBandStructure::getEnergies(WavevectorIndex &ik) {
   return x;
 }
 
+double FullBandStructure::getMaxEnergy() {
+  Error("Developer error: getMaxEnergy not implemented for fullbandstructure.");
+  return 0;
+}
+
 Eigen::Vector3d FullBandStructure::getGroupVelocity(StateIndex &is) {
   int stateIndex = is.get();
   auto tup = decompress2Indices(stateIndex, numPoints, numBands);

--- a/src/bands/bandstructure.h
+++ b/src/bands/bandstructure.h
@@ -111,6 +111,12 @@ class BaseBandStructure {
   virtual const double &getEnergy(StateIndex &is) = 0;
   virtual Eigen::VectorXd getEnergies(WavevectorIndex &ik) = 0;
 
+  /** Return the maximum energy of a bandstructure.
+  * Used when ph energy maximum is a cutoff for phel scattering.
+  * @return maxEnergy: maximum energy value of bandstructure in Ry
+  */
+  virtual double getMaxEnergy() = 0;
+
   /** Returns the energy of a quasiparticle from its Bloch index
    * Used for accessing the band structure in the BTE.
    * @param stateIndex: an integer index in range [0,numStates[
@@ -447,6 +453,12 @@ class FullBandStructure : public BaseBandStructure {
    */
   Eigen::VectorXd getEnergies(WavevectorIndex &ik) override;
 
+  /** Return the maximum energy of a bandstructure.
+  * Used when ph energy maximum is a cutoff for phel scattering.
+  * @return maxEnergy: maximum energy value of bandstructure in Ry
+  */
+  double getMaxEnergy() override;
+
   /** Returns the group velocity of a quasiparticle from its Bloch index.
    * Used for accessing the band structure in the BTE.
    * @param stateIndex: a StateIndex(is) object where 'is' is an integer index
@@ -675,7 +687,7 @@ protected:
   bool hasVelocities = false;
 
   // matrices storing the raw data
-  Matrix<double> energies;       // size(bands,points)
+  Matrix<double> energies;                    // size(bands,points)
   Matrix<std::complex<double>> velocities;    // size(3*bands^2,points)
   Matrix<std::complex<double>> eigenvectors;  // size(bands^2,points)
 

--- a/src/bands/bandstructure.h
+++ b/src/bands/bandstructure.h
@@ -16,7 +16,7 @@ class BaseBandStructure {
  public:
  
   /** Base destructor for bandstructure class, silences warnings */
-  virtual ~BaseBandStructure() = default;
+  //virtual ~BaseBandStructure() = default;
  
   /** Get the Particle object associated with this class
    * @return particle: a Particle object, describing e.g. whether this
@@ -313,7 +313,7 @@ class FullBandStructure : public BaseBandStructure {
                     bool withEigenvectors, Points &points_,
                     bool isDistributed_ = false);
 
-  FullBandStructure();
+  //FullBandStructure();
 
   /** Copy constructor
    */

--- a/src/bands/bandstructure.h
+++ b/src/bands/bandstructure.h
@@ -14,10 +14,10 @@
  */
 class BaseBandStructure {
  public:
- 
+
   /** Base destructor for bandstructure class, silences warnings */
-  //virtual ~BaseBandStructure() = default;
- 
+  virtual ~BaseBandStructure() = default;
+
   /** Get the Particle object associated with this class
    * @return particle: a Particle object, describing e.g. whether this
    * is a phonon or electron bandStructure

--- a/src/bte/el_scattering.h
+++ b/src/bte/el_scattering.h
@@ -1,7 +1,6 @@
 #ifndef EL_SCATTERING_H
 #define EL_SCATTERING_H
 
-#include "electron_h0_wannier.h"
 #include "interaction_elph.h"
 #include "phonon_h0.h"
 #include "scattering.h"

--- a/src/bte/helper_el_scattering.cpp
+++ b/src/bte/helper_el_scattering.cpp
@@ -8,14 +8,17 @@
 HelperElScattering::HelperElScattering(BaseBandStructure &innerBandStructure_,
                                BaseBandStructure &outerBandStructure_,
                                StatisticsSweep &statisticsSweep_,
-                               const int &smearingType_, PhononH0 &h0_, InteractionElPhWan *coupling)
-    : innerBandStructure(innerBandStructure_),
-      outerBandStructure(outerBandStructure_),
-      statisticsSweep(statisticsSweep_),
-      smearingType(smearingType_),
-      h0(h0_), couplingElPhWan(coupling) {
+                               const int &smearingType_, PhononH0 &h0_, 
+                               InteractionElPhWan *coupling)
+          : innerBandStructure(innerBandStructure_),
+            outerBandStructure(outerBandStructure_),
+            statisticsSweep(statisticsSweep_),
+            smearingType(smearingType_),
+            h0(h0_),
+            couplingElPhWan(coupling) {
+
   // three conditions must be met to avoid recomputing q3
-  // 1 - q1 and q2 mesh must be the same
+  // 1 - k1 and k2 mesh must be the same
   // 2 - the mesh is gamma-centered
   // 3 - the mesh is complete (if q1 and q2 are only around 0, q3 might be
   //     at the border)
@@ -23,7 +26,6 @@ HelperElScattering::HelperElScattering(BaseBandStructure &innerBandStructure_,
   Kokkos::Profiling::pushRegion("HelperElScattering");
 
   auto t1 = outerBandStructure.getPoints().getMesh();
-//  auto mesh = std::get<0>(t1);
   auto offset = std::get<1>(t1);
   storedAllQ3 = false;
 
@@ -31,6 +33,7 @@ HelperElScattering::HelperElScattering(BaseBandStructure &innerBandStructure_,
     std::cout << "Computing phonon band structure." << std::endl;
   }
 
+  // bandstructure are the same and are unfiltered 
   if ((&innerBandStructure == &outerBandStructure) && (offset.norm() == 0.) &&
       innerBandStructure.hasWindow() == 0) {
 
@@ -43,18 +46,20 @@ HelperElScattering::HelperElScattering(BaseBandStructure &innerBandStructure_,
 
     fullPoints3 = std::make_unique<Points>(
         innerBandStructure.getPoints().getCrystal(), mesh2, offset2);
+
     if (mpi->mpiHead()) { // print info on memory
       double x = h0.getNumBands() * fullPoints3->getNumPoints();
       x *= sizeof(x) / pow(1024,3);
       std::cout << std::setprecision(4);
       std::cout << "Allocating " << x << " GB (per MPI process)." << std::endl;
     }
-    bool withVelocities = true;
+
+    bool withVelocities = false; // these are never needed except sym adaptive smearing
     bool withEigenvectors = true;
-    FullBandStructure bs = h0.populate(*fullPoints3, withVelocities,
-                                               withEigenvectors);
+    FullBandStructure bs = h0.populate(*fullPoints3, withVelocities, withEigenvectors);
     bandStructure3 = std::make_unique<FullBandStructure>(bs);
 
+  // bandstructures the same, no offset, filtered bands 
   } else if ((&innerBandStructure == &outerBandStructure) &&
              (offset.norm() == 0.) && innerBandStructure.hasWindow() != 0) {
 
@@ -155,7 +160,7 @@ HelperElScattering::HelperElScattering(BaseBandStructure &innerBandStructure_,
 
     // build band structure
     bool withEigenvectors = true;
-    bool withVelocities = true;
+    bool withVelocities = false;
     // note: bandStructure3 stores a copy of ap3: can't pass unique_ptr
     bandStructure3 = std::make_unique<ActiveBandStructure>(
         ap3, &h0, withEigenvectors, withVelocities);
@@ -278,7 +283,10 @@ std::tuple<Eigen::Vector3d, Eigen::VectorXd, int, Eigen::MatrixXcd,
     int ik2Counter = ik2 - cacheOffset;
     Eigen::VectorXd energies3 = cacheEnergies[ik2Counter];
     Eigen::MatrixXcd eigenVectors3 = cacheEigenVectors[ik2Counter];
-    Eigen::MatrixXd v3s = cacheVelocity[ik2Counter];
+    Eigen::MatrixXd v3s; 
+    if (smearingType == DeltaFunction::adaptiveGaussian) {
+      v3s = cacheVelocity[ik2Counter];
+    }
     Eigen::MatrixXd bose3Data = cacheBose[ik2Counter];
     Eigen::VectorXcd polarData = cachePolarData[ik2Counter];
     int nb3 = int(energies3.size());
@@ -295,7 +303,9 @@ void HelperElScattering::prepare(const Eigen::Vector3d &k1,
     cacheEigenVectors.resize(numPoints);
     cacheBose.resize(numPoints);
     cachePolarData.resize(numPoints);
-    cacheVelocity.resize(numPoints);
+    if (smearingType == DeltaFunction::adaptiveGaussian) { 
+      cacheVelocity.resize(numPoints);
+    }
     cacheOffset = k2Indexes[0];
 
     Particle particle = h0.getParticle();
@@ -337,6 +347,7 @@ void HelperElScattering::prepare(const Eigen::Vector3d &k1,
             v3s(ib3, i) = v3sTmp(ib3, ib3, i).real();
           }
         }
+        cacheVelocity[ik2Counter] = v3s;
       }
 
       Eigen::VectorXcd polarData = couplingElPhWan->polarCorrectionPart1(q3, eigenVectors3);
@@ -345,7 +356,7 @@ void HelperElScattering::prepare(const Eigen::Vector3d &k1,
       cacheEigenVectors[ik2Counter] = eigenVectors3;
       cacheBose[ik2Counter] = bose3Data;
       cachePolarData[ik2Counter] = polarData;
-      cacheVelocity[ik2Counter] = v3s;
+      //cacheVelocity[ik2Counter] = v3s;
 
     }
   }

--- a/src/bte/helper_el_scattering.cpp
+++ b/src/bte/helper_el_scattering.cpp
@@ -318,6 +318,8 @@ void HelperElScattering::prepare(const Eigen::Vector3d &k1,
 
       Eigen::Vector3d q3 = k2 - k1;
 
+      // TODO this whole thing should be converted to kokkos 
+      // batched diagonalize from coordinates
       auto t1 = h0.diagonalizeFromCoordinates(q3);
       auto energies3 = std::get<0>(t1);
       auto eigenVectors3 = std::get<1>(t1);
@@ -329,6 +331,7 @@ void HelperElScattering::prepare(const Eigen::Vector3d &k1,
 
       for (int iCalc = 0; iCalc < statisticsSweep.getNumCalculations(); iCalc++) {
         double temp = statisticsSweep.getCalcStatistics(iCalc).temperature;
+        #pragma omp parallel for default(none) shared(bose3Data,iCalc,nb3,particle,energies3,temp)
         for (int ib3 = 0; ib3 < nb3; ib3++) {
           bose3Data(iCalc, ib3) = particle.getPopulation(energies3(ib3), temp);
         }

--- a/src/bte/helper_el_scattering.cpp
+++ b/src/bte/helper_el_scattering.cpp
@@ -8,13 +8,12 @@
 HelperElScattering::HelperElScattering(BaseBandStructure &innerBandStructure_,
                                BaseBandStructure &outerBandStructure_,
                                StatisticsSweep &statisticsSweep_,
-                               const int &smearingType_, PhononH0 &h0_, 
+                               const int &smearingType_, PhononH0 &h0_,
                                InteractionElPhWan *coupling)
           : innerBandStructure(innerBandStructure_),
             outerBandStructure(outerBandStructure_),
             statisticsSweep(statisticsSweep_),
-            smearingType(smearingType_),
-            h0(h0_),
+            smearingType(smearingType_), h0(h0_),
             couplingElPhWan(coupling) {
 
   // three conditions must be met to avoid recomputing q3
@@ -33,8 +32,8 @@ HelperElScattering::HelperElScattering(BaseBandStructure &innerBandStructure_,
     std::cout << "Computing phonon band structure." << std::endl;
   }
 
-  // bandstructure are the same and are unfiltered 
-  if ((outerBandStructure.getPoints() == innerBandStructure.getPoints()) 
+  // bandstructure are the same and are unfiltered
+  if ((outerBandStructure.getPoints() == innerBandStructure.getPoints())
       && (offset.norm() == 0.) && innerBandStructure.hasWindow() == 0) {
 
     storedAllQ3 = true;
@@ -59,7 +58,7 @@ HelperElScattering::HelperElScattering(BaseBandStructure &innerBandStructure_,
     FullBandStructure bs = h0.populate(*fullPoints3, withVelocities, withEigenvectors);
     bandStructure3 = std::make_unique<FullBandStructure>(bs);
 
-  // bandstructures the same, no offset, filtered bands 
+  // bandstructures the same, no offset, filtered bands
   } else if ((outerBandStructure.getPoints() == innerBandStructure.getPoints()) &&
              (offset.norm() == 0.) && innerBandStructure.hasWindow() != 0) {
 
@@ -283,7 +282,7 @@ std::tuple<Eigen::Vector3d, Eigen::VectorXd, int, Eigen::MatrixXcd,
     int ik2Counter = ik2 - cacheOffset;
     Eigen::VectorXd energies3 = cacheEnergies[ik2Counter];
     Eigen::MatrixXcd eigenVectors3 = cacheEigenVectors[ik2Counter];
-    Eigen::MatrixXd v3s; 
+    Eigen::MatrixXd v3s;
     if (smearingType == DeltaFunction::adaptiveGaussian) {
       v3s = cacheVelocity[ik2Counter];
     }
@@ -303,7 +302,7 @@ void HelperElScattering::prepare(const Eigen::Vector3d &k1,
     cacheEigenVectors.resize(numPoints);
     cacheBose.resize(numPoints);
     cachePolarData.resize(numPoints);
-    if (smearingType == DeltaFunction::adaptiveGaussian) { 
+    if (smearingType == DeltaFunction::adaptiveGaussian) {
       cacheVelocity.resize(numPoints);
     }
     cacheOffset = k2Indexes[0];
@@ -318,7 +317,7 @@ void HelperElScattering::prepare(const Eigen::Vector3d &k1,
 
       Eigen::Vector3d q3 = k2 - k1;
 
-      // TODO this whole thing should be converted to kokkos 
+      // TODO this whole thing should be converted to kokkos
       // batched diagonalize from coordinates
       auto t1 = h0.diagonalizeFromCoordinates(q3);
       auto energies3 = std::get<0>(t1);

--- a/src/bte/helper_el_scattering.cpp
+++ b/src/bte/helper_el_scattering.cpp
@@ -34,8 +34,8 @@ HelperElScattering::HelperElScattering(BaseBandStructure &innerBandStructure_,
   }
 
   // bandstructure are the same and are unfiltered 
-  if ((&innerBandStructure == &outerBandStructure) && (offset.norm() == 0.) &&
-      innerBandStructure.hasWindow() == 0) {
+  if ((outerBandStructure.getPoints() == innerBandStructure.getPoints()) 
+      && (offset.norm() == 0.) && innerBandStructure.hasWindow() == 0) {
 
     storedAllQ3 = true;
     storedAllQ3Case = storedAllQ3Case1;
@@ -60,7 +60,7 @@ HelperElScattering::HelperElScattering(BaseBandStructure &innerBandStructure_,
     bandStructure3 = std::make_unique<FullBandStructure>(bs);
 
   // bandstructures the same, no offset, filtered bands 
-  } else if ((&innerBandStructure == &outerBandStructure) &&
+  } else if ((outerBandStructure.getPoints() == innerBandStructure.getPoints()) &&
              (offset.norm() == 0.) && innerBandStructure.hasWindow() != 0) {
 
     storedAllQ3 = true;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -861,6 +861,8 @@ void Context::printInputSummary(const std::string &fileName) {
     if (appName.find("elPh") != std::string::npos || appName == "electronLifetimes" ||
         appName == "electronWannierTransport") {
 
+      if(qMesh.prod() != 0) std::cout << "qMesh = [" << qMesh(0) << ", " << qMesh(1) << ", " << qMesh(2) << " ]" << std::endl;
+
       std::cout << "elphFileName = " << elphFileName << std::endl;
       if (!elPhInterpolation.empty())
         std::cout << "elPhInterpolation = " << elPhInterpolation << std::endl;
@@ -928,11 +930,11 @@ void Context::printInputSummary(const std::string &fileName) {
         }
       } else {
         if(g2PlotStyle == "qFixed") {
-          std::cout << "kMesh = " << kMesh(0) << " " << kMesh(1) << " " << kMesh(2)
+          std::cout << "kMesh = [" << kMesh(0) << ", " << kMesh(1) << ", " << kMesh(2) << " ]"
                 << std::endl;
         }
         else if(g2PlotStyle == "kFixed") {
-          std::cout << "qMesh = " << qMesh(0) << " " << qMesh(1) << " " << qMesh(2)
+          std::cout << "qMesh = [" << qMesh(0) << ", " << qMesh(1) << ", " << qMesh(2) << " ]"
                 << std::endl;
         }
       }
@@ -949,7 +951,7 @@ void Context::printInputSummary(const std::string &fileName) {
       appName.find("Lifetimes") != std::string::npos) {
 
     if (appName.find("honon") != std::string::npos || appName.find("elPh") != std::string::npos) {
-      std::cout << "qMesh = " << qMesh(0) << " " << qMesh(1) << " " << qMesh(2) << std::endl;
+          std::cout << "qMesh = [" << qMesh(0) << ", " << qMesh(1) << ", " << qMesh(2) << " ]" << std::endl;
       if(!getElphFileName().empty()) {
         std::cout << "electronH0Name = " << electronH0Name << std::endl;
         std::cout << "hasSpinOrbit = " << hasSpinOrbit << std::endl;
@@ -958,7 +960,7 @@ void Context::printInputSummary(const std::string &fileName) {
     }
     if (appName.find("lectron") != std::string::npos || appName.find("elPh") != std::string::npos
                         || (appName.find("honon") != std::string::npos && !getElphFileName().empty())) {
-         std::cout << "kMesh = " << kMesh(0) << " " << kMesh(1) << " " << kMesh(2) << std::endl;
+         std::cout << "kMesh = [" << kMesh(0) << ", " << kMesh(1) << ", " << kMesh(2) << " ]" << std::endl;
     }
 
     if (!std::isnan(constantRelaxationTime))
@@ -1101,7 +1103,7 @@ void Context::printInputSummary(const std::string &fileName) {
     std::cout << "epaFileName = " << epaFileName << std::endl;
     std::cout << "electronH0Name = " << electronH0Name << std::endl;
     std::cout << "hasSpinOrbit = " << hasSpinOrbit << std::endl;
-    std::cout << "kMesh = " << kMesh(0) << " " << kMesh(1) << " " << kMesh(2)
+    std::cout << "kMesh = [" << kMesh(0) << ", " << kMesh(1) << ", " << kMesh(2) << " ]"
               << std::endl;
     if (!std::isnan(epaEnergyRange))
       std::cout << "epaEnergyRange = " << epaEnergyRange * energyRyToEv << " eV"

--- a/src/harmonic/phonon_h0.cpp
+++ b/src/harmonic/phonon_h0.cpp
@@ -779,15 +779,14 @@ void PhononH0::shortRangeTerm(Eigen::Tensor<std::complex<double>, 4> &dyn,
   Kokkos::Profiling::pushRegion("phononH0.shortRangeTerm");
 
   std::vector<std::complex<double>> phases(numBravaisVectors);
+#pragma omp parallel for default(none) shared(numBravaisVectors, bravaisVectors, q, complexI, phases)
   for (int iR = 0; iR < numBravaisVectors; iR++) {
     Eigen::Vector3d r = bravaisVectors.col(iR);
     double arg = q.dot(r);
     phases[iR] = exp(-complexI * arg); // {cos(arg), -sin(arg)};
-    //printf("old = %.16e %.16e\n", phases[iR].real(), phases[iR].imag());
-    //for(int i = 0; i < 3; i++)
-    //  printf("old = %.16e\n", r[i]);
   }
 
+#pragma omp parallel for collapse(5) default(none) shared(dyn, mat2R, phases, weights)
   for (int iR = 0; iR < numBravaisVectors; iR++) {
     for (int nb = 0; nb < numAtoms; nb++) {
       for (int na = 0; na < numAtoms; na++) {
@@ -800,15 +799,6 @@ void PhononH0::shortRangeTerm(Eigen::Tensor<std::complex<double>, 4> &dyn,
       }
     }
   }
-    //for (int nb = 0; nb < numAtoms; nb++) {
-    //  for (int na = 0; na < numAtoms; na++) {
-    //    for (int j : {0, 1, 2}) {
-    //      for (int i : {0, 1, 2}) {
-    //        printf("old = %.16e %.16e\n", dyn(i,j,na,nb).real(), dyn(i,j,na,nb).imag());
-    //      }
-    //    }
-    //  }
-    //}
   Kokkos::Profiling::popRegion();
 }
 

--- a/src/harmonic/phonon_h0.cpp
+++ b/src/harmonic/phonon_h0.cpp
@@ -779,28 +779,35 @@ void PhononH0::shortRangeTerm(Eigen::Tensor<std::complex<double>, 4> &dyn,
   Kokkos::Profiling::pushRegion("phononH0.shortRangeTerm");
 
   std::vector<std::complex<double>> phases(numBravaisVectors);
-#pragma omp parallel for default(none) shared(numBravaisVectors, bravaisVectors, q, complexI, phases)
+#pragma omp parallel for default(none) shared(numBravaisVectors, bravaisVectors, q, complexI, phases, weights)
   for (int iR = 0; iR < numBravaisVectors; iR++) {
     Eigen::Vector3d r = bravaisVectors.col(iR);
     double arg = q.dot(r);
     phases[iR] = exp(-complexI * arg); // {cos(arg), -sin(arg)};
   }
 
-#pragma omp declare reduction (+: Eigen::Tensor<std::complex<double>, 4>: omp_out=omp_out+omp_in)\
-     initializer(omp_priv=Eigen::Tensor<std::complex<double>, 4>(omp_orig.dimension(0),omp_orig.dimension(1),omp_orig.dimension(2),omp_orig.dimension(3)).setZero())
+//#pragma omp declare reduction (+: Eigen::Tensor<std::complex<double>, 4>: omp_out+=omp_in)\
+//     initializer(omp_priv=Eigen::Tensor<std::complex<double>, 4>(omp_orig.dimension(0),omp_orig.dimension(1),omp_orig.dimension(2),omp_orig.dimension(3)).setZero())
 
-#pragma omp parallel for collapse(5) default(none) reduction (+:dyn) shared(mat2R, phases, weights,numAtoms,numBravaisVectors)
+//#pragma omp parallel for collapse(5) default(none) reduction (+:dyn) shared(mat2R, phases, weights, numAtoms, numBravaisVectors) 
+#pragma omp 
+{
+  Eigen::Tensor<std::complex<double>, 4> tmpDyn(3,3,numAtoms,numAtoms);
+  tmpDyn.setZero();
   for (int iR = 0; iR < numBravaisVectors; iR++) {
     for (int nb = 0; nb < numAtoms; nb++) {
       for (int na = 0; na < numAtoms; na++) {
         for (int j : {0, 1, 2}) {
           for (int i : {0, 1, 2}) {
-            dyn(i, j, na, nb) +=  mat2R(i, j, na, nb, iR) * phases[iR] * weights(iR);
+            tmpDyn(i, j, na, nb) +=  mat2R(i, j, na, nb, iR) * phases[iR] * weights(iR);
           }
         }
       }
     }
-  }
+  } 
+  #pragma omp critical 
+  dyn += tmpDyn; 
+}
   Kokkos::Profiling::popRegion();
 }
 

--- a/src/harmonic/phonon_h0.cpp
+++ b/src/harmonic/phonon_h0.cpp
@@ -795,11 +795,11 @@ initializer(omp_priv=Eigen::Tensor<std::complex<double>, 4>(omp_orig.dimension(0
       for (int na = 0; na < numAtoms; na++) {
         for (int j : {0, 1, 2}) {
           for (int i : {0, 1, 2}) {
-            std::complex<double> tmp;
+            std::complex<double> tmp{0,0};
             for (int iR = 0; iR < numBravaisVectors; iR++) {
               tmp += mat2R(i, j, na, nb, iR) * phases[iR];
             }
-            dyn(i, j, na, nb) = tmp;
+            dyn(i, j, na, nb) += tmp;
           }
         }
       }

--- a/src/points.cpp
+++ b/src/points.cpp
@@ -21,6 +21,23 @@ Points::Points(Crystal &crystalObj_, const Eigen::Vector3i &mesh_,
   setupGVectors();
 }
 
+// comparison operator 
+bool Points::operator==(const Points &that) const {
+
+  bool isSame = true;
+  if(&crystalObj != &that.crystalObj) isSame = false; 
+  if(mesh != that.mesh) isSame = false; 
+  if(offset != that.offset) isSame = false; 
+  if(numPoints != that.numPoints) isSame = false; 
+  if(gVectors != that.gVectors) isSame = false; 
+  if(explicitlyStored != that.explicitlyStored) isSame = false; 
+  if(isPointsListSorted != that.isPointsListSorted) isSame = false; 
+  if(pointsList != that.pointsList) isSame = false; 
+  if(filteredToFullIndices != that.filteredToFullIndices) isSame = false; 
+  return isSame; 
+
+}
+
 void Points::setupGVectors() {
   // This block allows the folding to the wigner seitz zone
   int nGx = 2;

--- a/src/points.h
+++ b/src/points.h
@@ -102,6 +102,13 @@ public:
   Points(Crystal &crystal_, const Eigen::Tensor<double, 3> &pathExtrema,
          const double &delta);
 
+  /** default equals operator 
+   * ! cannot currently be defined because of reference member
+   * once crystal ref is converted to non ref, use default instead
+   */
+  //bool operator==(const Points& points) const = default;
+  bool operator==(const Points& points) const; 
+
   /** Constructor for Active Points
    * @param filter: a vector of integers of "filtered" points, i.e. the
    * indices of the wavevectors in parentPoints that we want to keep.
@@ -293,6 +300,7 @@ public:
 
 protected:
   void setMesh(const Eigen::Vector3i &mesh_, const Eigen::Vector3d &offset_);
+
   Crystal &crystalObj;
   Eigen::Vector3i mesh;
   Eigen::Vector3d offset;


### PR DESCRIPTION
Updates to allow the code to scale to larger system sizes, including more conservative allocation of band velocities for intermediate phonon states when using the RTA for electrons, and also the ability to use separate k and q meshes in the RTA electron BTE case. 

Further acceleration of the intermediate phonon state calculation when using RTA with different k/q should be investigated. Using the Kokkos batched functions with chunks of q points would be faster than the current implementation. 

Thanks to @MSimoncelli and @SiyuChen for pointing out the need for this in Issue #225 

