### PR TITLE
Minor fix in unary negation operator in matrix class 

### DIFF
--- a/src/algebra/Matrix.h
+++ b/src/algebra/Matrix.h
@@ -337,8 +337,8 @@ std::vector<std::tuple<int, int>> Matrix<T>::getAllLocalStates() {
 template <typename T>
 Matrix<T> Matrix<T>::operator-() const {
   Matrix<T> c(*this); // copy this matrix
-  if(isDistributed) c.pmat = -c.pmat;
-  else{ c.mat = -c.mat; }
+    if (isDistributed) *(c.pmat) = -*(c.pmat);
+    else               *(c.mat)  = -*(c.mat);
   return c;
 }
 


### PR DESCRIPTION
as noticed by @KeyneshDongol, with some compilers the unary negation operator in Matrix.h needs a dereference.